### PR TITLE
feat(support-for-error-templates): add the support of error templates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,11 @@
 			<artifactId>jacoco-maven-plugin</artifactId>
 			<version>0.8.5</version>
 		</dependency>
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.json</artifactId>
+			<version>1.1.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/io/apimatic/core/ErrorCase.java
+++ b/src/main/java/io/apimatic/core/ErrorCase.java
@@ -2,11 +2,6 @@ package io.apimatic.core;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.json.Json;
@@ -101,12 +96,6 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
         return new ErrorCase<ExceptionType>(reason, exceptionCreator, true);
     }
 
-    /**
-     * Replace the placeholder of error template.
-     * @param response A request response from server side.
-     * @param format A error template.
-     * @return A updated string.
-     */
     private void replacePlaceHolder(Response response) {
         replaceStatusCodeFromTemplate(response.getStatusCode());
         replaceHeadersFromTemplate(response.getHeaders());
@@ -153,7 +142,7 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
                         String toReplaceString = responseBody;
                         if (jsonPointer.containsValue(jsonStructure)) {
                             toReplaceString = jsonPointer.getValue(jsonStructure).toString();
-                        } 
+                        }
                         formatter.replace(index, index + formatKey.length(), toReplaceString);
                     } catch (JsonException ex) {
                         formatter.replace(index, index + formatKey.length(), "");

--- a/src/main/java/io/apimatic/core/ErrorCase.java
+++ b/src/main/java/io/apimatic/core/ErrorCase.java
@@ -35,7 +35,7 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
     /**
      * Error message a template or not.
      */
-    private static boolean isErrorTemplate;
+    private boolean isErrorTemplate;
 
     /**
      * An instance of {@link ExceptionCreator}.
@@ -47,9 +47,10 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
      * @param reason the exception reason.
      * @param exceptionCreator the exceptionCreator.
      */
-    private ErrorCase(final String reason, final ExceptionCreator<ExceptionType> exceptionCreator) {
+    private ErrorCase(final String reason, final ExceptionCreator<ExceptionType> exceptionCreator, boolean isErrorTemplate) {
         this.reason = reason;
         this.exceptionCreator = exceptionCreator;
+        this.isErrorTemplate = isErrorTemplate;
     }
 
     /**
@@ -73,7 +74,7 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
      */
     public static <ExceptionType extends CoreApiException> ErrorCase<ExceptionType> create(
             String reason, ExceptionCreator<ExceptionType> exceptionCreator) {
-        ErrorCase<ExceptionType> errorCase = new ErrorCase<ExceptionType>(reason, exceptionCreator);
+        ErrorCase<ExceptionType> errorCase = new ErrorCase<ExceptionType>(reason, exceptionCreator, false);
         return errorCase;
     }
 
@@ -88,8 +89,7 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
      */
     public static <ExceptionType extends CoreApiException> ErrorCase<ExceptionType> createErrorTemplate(
             String reason, ExceptionCreator<ExceptionType> exceptionCreator) {
-        isErrorTemplate = true;
-        return new ErrorCase<ExceptionType>(reason, exceptionCreator);
+        return new ErrorCase<ExceptionType>(reason, exceptionCreator, true);
     }
 
 
@@ -108,13 +108,13 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
      * @return A updated string
      */
     private String replacePlaceHolder(Response response, String format) {
-        format = replaceStatusCodePlaceHolder(format, response.getStatusCode()); // improve the method name
-        format = replaceHeadersPlaceHolder(format, response.getHeaders());
-        format = replaceBodyPlaceHolder(format, response.getBody());
+        format = replaceStatusCodeFromTemplate(format, response.getStatusCode()); 
+        format = replaceHeadersFromTemplate(format, response.getHeaders());
+        format = replaceBodyFromTemplate(format, response.getBody());
         return format;
     }
 
-    private String replaceHeadersPlaceHolder(String format, HttpHeaders headers) {
+    private String replaceHeadersFromTemplate(String format, HttpHeaders headers) {
         StringBuilder formatter = new StringBuilder(format);
         Matcher matcher = Pattern.compile("\\{(.*?)\\}").matcher(format);
         while (matcher.find()) {
@@ -133,7 +133,7 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
         return formatter.toString();
     }
 
-    private String replaceBodyPlaceHolder(String format, String responseBody) {
+    private String replaceBodyFromTemplate(String format, String responseBody) {
         InputStream inputStream = new ByteArrayInputStream(responseBody.getBytes());
         Reader reader = new InputStreamReader(inputStream);
         StringBuilder formatter = new StringBuilder(format);
@@ -164,7 +164,7 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
         return formatter.toString();
     }
 
-    private static String replaceStatusCodePlaceHolder(String format, int statusCode) {
+    private static String replaceStatusCodeFromTemplate(String format, int statusCode) {
         StringBuilder formatter = new StringBuilder(format);
         Matcher matcher = Pattern.compile("\\{(.*?)\\}").matcher(format);
         while (matcher.find()) {

--- a/src/main/java/io/apimatic/core/ErrorCase.java
+++ b/src/main/java/io/apimatic/core/ErrorCase.java
@@ -74,7 +74,7 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
      *        thrown exception.
      * @return {@link ErrorCase}.
      */
-    public static <ExceptionType extends CoreApiException> ErrorCase<ExceptionType> create(
+    public static <ExceptionType extends CoreApiException> ErrorCase<ExceptionType> setReason(
             String reason, ExceptionCreator<ExceptionType> exceptionCreator) {
         ErrorCase<ExceptionType> errorCase =
                 new ErrorCase<ExceptionType>(reason, exceptionCreator, false);
@@ -90,7 +90,7 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
      *        thrown exception.
      * @return {@link ErrorCase}.
      */
-    public static <ExceptionType extends CoreApiException> ErrorCase<ExceptionType> createErrorTemplate(
+    public static <ExceptionType extends CoreApiException> ErrorCase<ExceptionType> setTemplate(
             String reason, ExceptionCreator<ExceptionType> exceptionCreator) {
         return new ErrorCase<ExceptionType>(reason, exceptionCreator, true);
     }

--- a/src/main/java/io/apimatic/core/ErrorCase.java
+++ b/src/main/java/io/apimatic/core/ErrorCase.java
@@ -1,7 +1,20 @@
 package io.apimatic.core;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.json.Json;
+import javax.json.JsonException;
+import javax.json.JsonPointer;
+import javax.json.JsonReader;
+import javax.json.JsonStructure;
 import io.apimatic.core.types.CoreApiException;
 import io.apimatic.coreinterfaces.http.Context;
+import io.apimatic.coreinterfaces.http.HttpHeaders;
+import io.apimatic.coreinterfaces.http.response.Response;
 import io.apimatic.coreinterfaces.type.functional.ExceptionCreator;
 
 /**
@@ -18,6 +31,11 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
      * A error's reason.
      */
     private String reason;
+
+    /**
+     * Error message a template or not.
+     */
+    private static boolean isErrorTemplate;
 
     /**
      * An instance of {@link ExceptionCreator}.
@@ -41,7 +59,7 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
      * @throws ExceptionType Represents error response from the server.
      */
     public void throwException(Context httpContext) throws ExceptionType {
-        throw exceptionCreator.apply(reason, httpContext);
+        throw exceptionCreator.apply(getReason(httpContext), httpContext);
     }
 
     /**
@@ -59,4 +77,106 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
         return errorCase;
     }
 
+    /**
+     * Create the errorcase using the error reason and exception creator functional interface which
+     * throws the respective exception while throwing.
+     * @param <ExceptionType> Represents error response from the server.
+     * @param reason the exception message.
+     * @param exceptionCreator the functional interface which is responsible to create the server
+     *        thrown exception.
+     * @return {@link ErrorCase}.
+     */
+    public static <ExceptionType extends CoreApiException> ErrorCase<ExceptionType> createErrorTemplate(
+            String reason, ExceptionCreator<ExceptionType> exceptionCreator) {
+        isErrorTemplate = true;
+        return new ErrorCase<ExceptionType>(reason, exceptionCreator);
+    }
+
+
+    private String getReason(Context context) {
+        if (!isErrorTemplate) {
+            return reason;
+        }
+        reason = replacePlaceHolder(context.getResponse(), reason);
+        return reason;
+    }
+
+    /**
+     * Replace the placeholder of error template.
+     * @param response A request response from server side.
+     * @param format A error template.
+     * @return A updated string
+     */
+    private String replacePlaceHolder(Response response, String format) {
+        format = replaceStatusCodePlaceHolder(format, response.getStatusCode()); // improve the method name
+        format = replaceHeadersPlaceHolder(format, response.getHeaders());
+        format = replaceBodyPlaceHolder(format, response.getBody());
+        return format;
+    }
+
+    private String replaceHeadersPlaceHolder(String format, HttpHeaders headers) {
+        StringBuilder formatter = new StringBuilder(format);
+        Matcher matcher = Pattern.compile("\\{(.*?)\\}").matcher(format);
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            String pointerKey = key;
+            if (pointerKey.startsWith("$response.header.")) {
+                pointerKey = pointerKey.replace("$response.header.", "");
+                String formatKey = String.format("{%s}", key);
+                int index = formatter.indexOf(formatKey);
+                if (index != -1) {
+                    formatter.replace(index, index + formatKey.length(),
+                            "" + (headers.has(pointerKey) ? headers.value(pointerKey) : ""));
+                }
+            }
+        }
+        return formatter.toString();
+    }
+
+    private String replaceBodyPlaceHolder(String format, String responseBody) {
+        InputStream inputStream = new ByteArrayInputStream(responseBody.getBytes());
+        Reader reader = new InputStreamReader(inputStream);
+        StringBuilder formatter = new StringBuilder(format);
+        Matcher matcher = Pattern.compile("\\{(.*?)\\}").matcher(format);
+        JsonReader JsonReader = Json.createReader(reader);
+        JsonStructure jsonStructure = JsonReader.read();
+        JsonReader.close();
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            String pointerKey = key;
+            if (pointerKey.startsWith("$response.body#")) {
+                pointerKey = pointerKey.replace("$response.body#", "");
+                JsonPointer jsonPointer = Json.createPointer(pointerKey);
+                String formatKey = String.format("{%s}", key);
+                int index = formatter.indexOf(formatKey);
+                if (index != -1) {
+                    try {
+                        formatter.replace(index, index + formatKey.length(),
+                                "" + (jsonPointer.containsValue(jsonStructure)
+                                        ? jsonPointer.getValue(jsonStructure).toString().replaceAll("^\"|\"$", "")
+                                        : ""));
+                    } catch (JsonException ex) {
+                        formatter.replace(index, index + formatKey.length(), "");
+                    }
+                }
+            }
+        }
+        return formatter.toString();
+    }
+
+    private static String replaceStatusCodePlaceHolder(String format, int statusCode) {
+        StringBuilder formatter = new StringBuilder(format);
+        Matcher matcher = Pattern.compile("\\{(.*?)\\}").matcher(format);
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            if (key.equals("$statusCode")) {
+                String formatKey = String.format("{%s}", key);
+                int index = formatter.indexOf(formatKey);
+                if (index != -1) {
+                    formatter.replace(index, index + formatKey.length(), "" + statusCode);
+                }
+            }
+        }
+        return formatter.toString();
+    }
 }

--- a/src/main/java/io/apimatic/core/ErrorCase.java
+++ b/src/main/java/io/apimatic/core/ErrorCase.java
@@ -46,8 +46,10 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
      * A private constructor.
      * @param reason the exception reason.
      * @param exceptionCreator the exceptionCreator.
+     * @param isErrorTemplate error case for error template.
      */
-    private ErrorCase(final String reason, final ExceptionCreator<ExceptionType> exceptionCreator, boolean isErrorTemplate) {
+    private ErrorCase(final String reason, final ExceptionCreator<ExceptionType> exceptionCreator,
+            boolean isErrorTemplate) {
         this.reason = reason;
         this.exceptionCreator = exceptionCreator;
         this.isErrorTemplate = isErrorTemplate;
@@ -74,7 +76,8 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
      */
     public static <ExceptionType extends CoreApiException> ErrorCase<ExceptionType> create(
             String reason, ExceptionCreator<ExceptionType> exceptionCreator) {
-        ErrorCase<ExceptionType> errorCase = new ErrorCase<ExceptionType>(reason, exceptionCreator, false);
+        ErrorCase<ExceptionType> errorCase =
+                new ErrorCase<ExceptionType>(reason, exceptionCreator, false);
         return errorCase;
     }
 
@@ -105,10 +108,10 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
      * Replace the placeholder of error template.
      * @param response A request response from server side.
      * @param format A error template.
-     * @return A updated string
+     * @return A updated string.
      */
     private String replacePlaceHolder(Response response, String format) {
-        format = replaceStatusCodeFromTemplate(format, response.getStatusCode()); 
+        format = replaceStatusCodeFromTemplate(format, response.getStatusCode());
         format = replaceHeadersFromTemplate(format, response.getHeaders());
         format = replaceBodyFromTemplate(format, response.getBody());
         return format;
@@ -138,9 +141,9 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
         Reader reader = new InputStreamReader(inputStream);
         StringBuilder formatter = new StringBuilder(format);
         Matcher matcher = Pattern.compile("\\{(.*?)\\}").matcher(format);
-        JsonReader JsonReader = Json.createReader(reader);
-        JsonStructure jsonStructure = JsonReader.read();
-        JsonReader.close();
+        JsonReader jsonReader = Json.createReader(reader);
+        JsonStructure jsonStructure = jsonReader.read();
+        jsonReader.close();
         while (matcher.find()) {
             String key = matcher.group(1);
             String pointerKey = key;
@@ -153,7 +156,8 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
                     try {
                         formatter.replace(index, index + formatKey.length(),
                                 "" + (jsonPointer.containsValue(jsonStructure)
-                                        ? jsonPointer.getValue(jsonStructure).toString().replaceAll("^\"|\"$", "")
+                                        ? jsonPointer.getValue(jsonStructure).toString()
+                                                .replaceAll("^\"|\"$", "")
                                         : ""));
                     } catch (JsonException ex) {
                         formatter.replace(index, index + formatKey.length(), "");

--- a/src/main/java/io/apimatic/core/ErrorCase.java
+++ b/src/main/java/io/apimatic/core/ErrorCase.java
@@ -127,7 +127,8 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
         JsonStructure jsonStructure = null;
         try {
             jsonStructure = jsonReader.read();
-        }catch (Exception e) {
+        } catch (Exception e) {
+            // No need to do anything here
         }
         jsonReader.close();
         Matcher matcher = Pattern.compile("\\{(.*?)\\}").matcher(reason);

--- a/src/main/java/io/apimatic/core/ResponseHandler.java
+++ b/src/main/java/io/apimatic/core/ResponseHandler.java
@@ -310,7 +310,7 @@ public final class ResponseHandler<ResponseType, ExceptionType extends CoreApiEx
          * @param <IntermediateResponseType> the intermediate type of api response.
          * @return {@link ResponseHandler.Builder}.
          */
-        public <IntermediateResponseType> Builder<ResponseType, ExceptionType> 
+        public <IntermediateResponseType> Builder<ResponseType, ExceptionType>
                 apiResponseDeserializer(
                         Deserializer<IntermediateResponseType> intermediateDeserializer) {
             this.intermediateDeserializer = intermediateDeserializer;

--- a/src/main/java/io/apimatic/core/ResponseHandler.java
+++ b/src/main/java/io/apimatic/core/ResponseHandler.java
@@ -204,15 +204,15 @@ public final class ResponseHandler<ResponseType, ExceptionType extends CoreApiEx
         String errorCode = String.valueOf(statusCode);
 
 
-        ThrowConfiguredException(localErrorCases, errorCode, httpContext);
-        ThrowConfiguredException(globalErrorCases, errorCode, httpContext);
+        throwConfiguredException(localErrorCases, errorCode, httpContext);
+        throwConfiguredException(globalErrorCases, errorCode, httpContext);
 
         if ((statusCode < MIN_SUCCESS_CODE) || (statusCode > MAX_SUCCESS_CODE)) {
             globalErrorCases.get(ErrorCase.DEFAULT).throwException(httpContext);
         }
     }
 
-    private void ThrowConfiguredException(Map<String, ErrorCase<ExceptionType>> errorCases,
+    private void throwConfiguredException(Map<String, ErrorCase<ExceptionType>> errorCases,
             String errorCode, Context httpContext) throws ExceptionType {
         String defaultErrorCode = "";
         Matcher match = Pattern.compile("^[(4|5)[0-9]]{3}").matcher(errorCode);
@@ -310,8 +310,9 @@ public final class ResponseHandler<ResponseType, ExceptionType extends CoreApiEx
          * @param <IntermediateResponseType> the intermediate type of api response.
          * @return {@link ResponseHandler.Builder}.
          */
-        public <IntermediateResponseType> Builder<ResponseType, ExceptionType> apiResponseDeserializer(
-                Deserializer<IntermediateResponseType> intermediateDeserializer) {
+        public <IntermediateResponseType> Builder<ResponseType, ExceptionType> 
+                apiResponseDeserializer(
+                        Deserializer<IntermediateResponseType> intermediateDeserializer) {
             this.intermediateDeserializer = intermediateDeserializer;
             return this;
         }

--- a/src/test/java/apimatic/core/EndToEndTest.java
+++ b/src/test/java/apimatic/core/EndToEndTest.java
@@ -116,16 +116,16 @@ public class EndToEndTest extends MockCoreConfig {
      */
     @Test
     public void testLocalErrorTemplateBody() throws IOException, CoreApiException {
-        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+        String responseString = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
                 + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
                 + "      \"code\": \"UNAUTHORIZED\",\r\n"
                 + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
                 + "  ]\r\n" + "}\r\n" + "\r\n";
         Exception exception = assertThrows(CoreApiException.class, () -> {
-            getApiCallLocalErrorTemplate(response, BAD_REQUEST).execute();
+            getApiCallLocalErrorTemplate(responseString, BAD_REQUEST).execute();
         });
-        String expected =
-                "Failed to make the request, 400 UNAUTHORIZED - This request could not be authorized.";
+        String expected = "Failed to make the request, 400 UNAUTHORIZED - "
+                + "This request could not be authorized.";
         String actual = exception.getMessage();
         assertEquals(actual, expected);
     }
@@ -138,16 +138,16 @@ public class EndToEndTest extends MockCoreConfig {
      */
     @Test
     public void testGlobalErrorTemplateBody() throws IOException, CoreApiException {
-        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+        String responseString = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
                 + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
                 + "      \"code\": \"UNAUTHORIZED\",\r\n"
                 + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
                 + "  ]\r\n" + "}\r\n" + "\r\n";
         Exception exception = assertThrows(GlobalTestException.class, () -> {
-            getApiCallGlobalErrorTemplate(response, BAD_REQUEST).execute();
+            getApiCallGlobalErrorTemplate(responseString, BAD_REQUEST).execute();
         });
-        String expected =
-                "Failed to make the request, 400 UNAUTHORIZED - This request could not be authorized.";
+        String expected = "Failed to make the request, 400 UNAUTHORIZED - "
+                + "This request could not be authorized.";
         String actual = exception.getMessage();
         assertEquals(actual, expected);
     }
@@ -159,12 +159,12 @@ public class EndToEndTest extends MockCoreConfig {
      */
     @Test
     public void testGlobalErrorTemplateMissingBody() throws IOException, CoreApiException {
-        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+        String responseString = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
                 + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
                 + "      \"code\": \"UNAUTHORIZED\"\r\n" + "    }\r\n" + "  ]\r\n" + "}\r\n"
                 + "\r\n";
         Exception exception = assertThrows(GlobalTestException.class, () -> {
-            getApiCallGlobalErrorTemplate(response, BAD_REQUEST).execute();
+            getApiCallGlobalErrorTemplate(responseString, BAD_REQUEST).execute();
         });
         String expected = "Failed to make the request, 400 UNAUTHORIZED - ";
         String actual = exception.getMessage();
@@ -178,13 +178,13 @@ public class EndToEndTest extends MockCoreConfig {
      */
     @Test
     public void testGlobalErrorTemplateMissingStatusCode() throws IOException, CoreApiException {
-        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+        String responseString = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
                 + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
                 + "      \"code\": \"UNAUTHORIZED\",\r\n"
                 + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
                 + "  ]\r\n" + "}\r\n" + "\r\n";
         Exception exception = assertThrows(CoreApiException.class, () -> {
-            getApiCallGlobalErrorTemplate(response, TOO_MANY_REQUEST).execute();
+            getApiCallGlobalErrorTemplate(responseString, TOO_MANY_REQUEST).execute();
         });
         String expected =
                 "Failed to make the request, UNAUTHORIZED - This request could not be authorized.";
@@ -199,16 +199,16 @@ public class EndToEndTest extends MockCoreConfig {
      */
     @Test
     public void testGlobalErrorTemplateHeaders() throws IOException, CoreApiException {
-        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+        String responseString = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
                 + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
                 + "      \"code\": \"UNAUTHORIZED\",\r\n"
                 + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
                 + "  ]\r\n" + "}\r\n" + "\r\n";
         Exception exception = assertThrows(CoreApiException.class, () -> {
-            getApiCallGlobalErrorTemplateWithHeaders(response, UNAUTHORIZED).execute();
+            getApiCallGlobalErrorTemplateWithHeaders(responseString, UNAUTHORIZED).execute();
         });
-        String expected =
-                "Failed to make the request, application/json UNAUTHORIZED - This request could not be authorized.";
+        String expected = "Failed to make the request, application/json UNAUTHORIZED - "
+                + "This request could not be authorized.";
         String actual = exception.getMessage();
         assertEquals(actual, expected);
     }
@@ -220,20 +220,20 @@ public class EndToEndTest extends MockCoreConfig {
      */
     @Test
     public void testGlobalErrorTemplateHeadersMissing() throws IOException, CoreApiException {
-        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+        String responseString = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
                 + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
                 + "      \"code\": \"UNAUTHORIZED\",\r\n"
                 + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
                 + "  ]\r\n" + "}\r\n" + "\r\n";
         Exception exception = assertThrows(CoreApiException.class, () -> {
-            getApiCallGlobalErrorTemplateWithHeaders(response, METHOD_NOT_ALLOWED).execute();
+            getApiCallGlobalErrorTemplateWithHeaders(responseString, METHOD_NOT_ALLOWED).execute();
         });
-        String expected =
-                "Failed to make the request,  UNAUTHORIZED - This request could not be authorized.";
+        String expected = "Failed to make the request,  UNAUTHORIZED - "
+                + "This request could not be authorized.";
         String actual = exception.getMessage();
         assertEquals(actual, expected);
     }
-    
+
     /**
      * Test the Global Error template missing headers.
      * @throws IOException Signals that an I/O exception of some sort has occurred.
@@ -241,20 +241,20 @@ public class EndToEndTest extends MockCoreConfig {
      */
     @Test
     public void testGlobalErrorTemplate4XX() throws IOException, CoreApiException {
-        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+        String responseString = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
                 + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
                 + "      \"code\": \"UNAUTHORIZED\",\r\n"
                 + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
                 + "  ]\r\n" + "}\r\n" + "\r\n";
         Exception exception = assertThrows(CoreApiException.class, () -> {
-            getApiCallGlobalErrorTemplateWithHeaders(response, 415).execute();
+            getApiCallGlobalErrorTemplateWithHeaders(responseString, 415).execute();
         });
-        String expected =
-                "Failed to make the request, UNAUTHORIZED - This request could not be authorized.";
+        String expected = "Failed to make the request, UNAUTHORIZED - "
+                + "This request could not be authorized.";
         String actual = exception.getMessage();
         assertEquals(actual, expected);
     }
-    
+
     /**
      * Test the Global Error template missing headers.
      * @throws IOException Signals that an I/O exception of some sort has occurred.
@@ -262,16 +262,15 @@ public class EndToEndTest extends MockCoreConfig {
      */
     @Test
     public void testGlobalErrorTemplate5XX() throws IOException, CoreApiException {
-        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+        String responseString = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
                 + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
                 + "      \"code\": \"UNAUTHORIZED\",\r\n"
                 + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
                 + "  ]\r\n" + "}\r\n" + "\r\n";
         Exception exception = assertThrows(CoreApiException.class, () -> {
-            getApiCallGlobalErrorTemplateWithHeaders(response, 500).execute();
+            getApiCallGlobalErrorTemplateWithHeaders(responseString, 500).execute();
         });
-        String expected =
-                "Failed to make the request, http status code: 500";
+        String expected = "Failed to make the request, http status code: 500";
         String actual = exception.getMessage();
         assertEquals(actual, expected);
     }
@@ -311,9 +310,12 @@ public class EndToEndTest extends MockCoreConfig {
                         .authenticationKey("global").httpMethod(Method.GET))
                 .responseHandler(responseHandler -> responseHandler
                         .deserializer(response -> CoreHelper.deserialize(response, String.class))
-                        .localErrorCase("400", ErrorCase.createErrorTemplate(
-                                "Failed to make the request, {$statusCode} {$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
-                                (reason, context) -> new CoreApiException(reason, context)))
+                        .localErrorCase("400",
+                                ErrorCase.createErrorTemplate(
+                                        "Failed to make the request, {$statusCode} "
+                                                + "{$response.body#/errors/0/code} - "
+                                                + "{$response.body#/errors/0/detail}",
+                                        (reason, context) -> new CoreApiException(reason, context)))
                         .nullify404(false).globalErrorCase(Collections.emptyMap()))
                 .endpointConfiguration(
                         param -> param.arraySerializationFormat(ArraySerializationFormat.INDEXED)
@@ -401,31 +403,39 @@ public class EndToEndTest extends MockCoreConfig {
     private Map<String, ErrorCase<CoreApiException>> getGlobalErrorCases() {
         Map<String, ErrorCase<CoreApiException>> globalErrorCase = new HashMap<>();
         globalErrorCase.put("400", ErrorCase.createErrorTemplate(
-                "Failed to make the request, {$statusCode} {$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
+                "Failed to make the request, {$statusCode} {$response.body#/errors/0/code} - "
+                        + "{$response.body#/errors/0/detail}",
                 (reason, context) -> new GlobalTestException(reason, context)));
 
         globalErrorCase.put("404", ErrorCase.create("Not found",
                 (reason, context) -> new CoreApiException(reason, context)));
 
         globalErrorCase.put("401", ErrorCase.createErrorTemplate(
-                "Failed to make the request, {$response.header.content-type} {$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
+                "Failed to make the request, {$response.header.content-type} "
+                        + "{$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
                 (reason, context) -> new CoreApiException(reason, context)));
 
         globalErrorCase.put("405", ErrorCase.createErrorTemplate(
-                "Failed to make the request, {$response.header.accept} {$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
-                (reason, context) -> new CoreApiException(reason, context)));
-        
-        globalErrorCase.put("500", ErrorCase.createErrorTemplate(
-                "Failed to make the request, http status code: {$statusCode}",
-                (reason, context) -> new CoreApiException(reason, context)));
-        
-        globalErrorCase.put("4XX", ErrorCase.createErrorTemplate(
-                "Failed to make the request, {$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
+                "Failed to make the request, {$response.header.accept} "
+                        + "{$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
                 (reason, context) -> new CoreApiException(reason, context)));
 
-        globalErrorCase.put(ErrorCase.DEFAULT, ErrorCase.create(
-                "Failed to make the request, {$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
-                (reason, context) -> new CoreApiException(reason, context)));
+        globalErrorCase.put("500",
+                ErrorCase.createErrorTemplate(
+                        "Failed to make the request, http status code: {$statusCode}",
+                        (reason, context) -> new CoreApiException(reason, context)));
+
+        globalErrorCase.put("4XX",
+                ErrorCase.createErrorTemplate(
+                        "Failed to make the request, {$response.body#/errors/0/code} -"
+                                + " {$response.body#/errors/0/detail}",
+                        (reason, context) -> new CoreApiException(reason, context)));
+
+        globalErrorCase.put(ErrorCase.DEFAULT,
+                ErrorCase.create(
+                        "Failed to make the request, {$response.body#/errors/0/code} - "
+                                + "{$response.body#/errors/0/detail}",
+                        (reason, context) -> new CoreApiException(reason, context)));
 
         return globalErrorCase;
 

--- a/src/test/java/apimatic/core/EndToEndTest.java
+++ b/src/test/java/apimatic/core/EndToEndTest.java
@@ -314,7 +314,7 @@ public class EndToEndTest extends MockCoreConfig {
                 .responseHandler(responseHandler -> responseHandler
                         .deserializer(response -> CoreHelper.deserialize(response, String.class))
                         .localErrorCase("400",
-                                ErrorCase.createErrorTemplate(
+                                ErrorCase.setTemplate(
                                         "Failed to make the request, {$statusCode} "
                                                 + "{$response.body#/errors/0/code} - "
                                                 + "{$response.body#/errors/0/detail}",
@@ -405,37 +405,37 @@ public class EndToEndTest extends MockCoreConfig {
 
     private Map<String, ErrorCase<CoreApiException>> getGlobalErrorCases() {
         Map<String, ErrorCase<CoreApiException>> globalErrorCase = new HashMap<>();
-        globalErrorCase.put("400", ErrorCase.createErrorTemplate(
+        globalErrorCase.put("400", ErrorCase.setTemplate(
                 "Failed to make the request, {$statusCode} {$response.body#/errors/0/code} - "
                         + "{$response.body#/errors/0/detail}",
                 (reason, context) -> new GlobalTestException(reason, context)));
 
-        globalErrorCase.put("404", ErrorCase.create("Not found",
+        globalErrorCase.put("404", ErrorCase.setReason("Not found",
                 (reason, context) -> new CoreApiException(reason, context)));
 
-        globalErrorCase.put("401", ErrorCase.createErrorTemplate(
+        globalErrorCase.put("401", ErrorCase.setTemplate(
                 "Failed to make the request, {$response.header.content-type} "
                         + "{$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
                 (reason, context) -> new CoreApiException(reason, context)));
 
-        globalErrorCase.put("405", ErrorCase.createErrorTemplate(
+        globalErrorCase.put("405", ErrorCase.setTemplate(
                 "Failed to make the request, {$response.header.accept} "
                         + "{$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
                 (reason, context) -> new CoreApiException(reason, context)));
 
         globalErrorCase.put("500",
-                ErrorCase.createErrorTemplate(
+                ErrorCase.setTemplate(
                         "Failed to make the request, http status code: {$statusCode}",
                         (reason, context) -> new CoreApiException(reason, context)));
 
         globalErrorCase.put("4XX",
-                ErrorCase.createErrorTemplate(
+                ErrorCase.setTemplate(
                         "Failed to make the request, {$response.body#/errors/0/code} -"
                                 + " {$response.body#/errors/0/detail}",
                         (reason, context) -> new CoreApiException(reason, context)));
 
         globalErrorCase.put(ErrorCase.DEFAULT,
-                ErrorCase.create(
+                ErrorCase.setReason(
                         "Failed to make the request, {$response.body#/errors/0/code} - "
                                 + "{$response.body#/errors/0/detail}",
                         (reason, context) -> new CoreApiException(reason, context)));

--- a/src/test/java/apimatic/core/EndToEndTest.java
+++ b/src/test/java/apimatic/core/EndToEndTest.java
@@ -189,18 +189,62 @@ public class EndToEndTest extends MockCoreConfig {
         Exception exception = assertThrows(GlobalTestException.class, () -> {
             getApiCallGlobalErrorTemplate(responseString, BAD_REQUEST).execute();
         });
-        String expected = "Failed to make the request, 400 UNAUTHORIZED - {\r\n"
-                + "  errors: [\r\n"
-                + "    {\r\n"
-                + "      category: AUTHENTICATION_ERROR,\r\n"
-                + "      code: UNAUTHORIZED\r\n"
-                + "    }\r\n"
-                + "  ]\r\n"
-                + "}";
+        String expected = "Failed to make the request, 400 UNAUTHORIZED -";
         String actual = exception.getMessage().trim();
         assertEquals(actual, expected);
     }
 
+    /**
+     * Test the Global Error template.
+     * @throws IOException Signals that an I/O exception of some sort has occurred.
+     * @throws CoreApiException Exception in api call execution.
+     */
+    @Test
+    public void testGlobalErrorTemplateUnknownPropertyBody() throws IOException, CoreApiException {
+        String responseString = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+                + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
+                + "      \"code\": \"UNAUTHORIZED\"\r\n" + "    }\r\n" + "  ]\r\n" + "}\r\n"
+                + "\r\n";
+        Exception exception = assertThrows(GlobalTestException.class, () -> {
+            getApiCallGlobalErrorTemplate(responseString, BAD_REQUEST).execute();
+        });
+        String expected = "Failed to make the request, 400 UNAUTHORIZED -";
+        String actual = exception.getMessage().trim();
+        assertEquals(actual, expected);
+    }
+    
+    /**
+     * Test the Global Error template.
+     * @throws IOException Signals that an I/O exception of some sort has occurred.
+     * @throws CoreApiException Exception in api call execution.
+     */
+    @Test
+    public void testGlobalErrorTemplateScalarBody() throws IOException, CoreApiException {
+        String responseString = "\"true\"";
+        Exception exception = assertThrows(GlobalTestException.class, () -> {
+            getApiCallGlobalErrorTemplate(responseString, BAD_REQUEST).execute();
+        });
+        String expected = "Failed to make the request, 400  -";
+        String actual = exception.getMessage().trim();
+        assertEquals(actual, expected);
+    }
+    
+    /**
+     * Test the Global Error template.
+     * @throws IOException Signals that an I/O exception of some sort has occurred.
+     * @throws CoreApiException Exception in api call execution.
+     */
+    @Test
+    public void testGlobalErrorTemplateExistScalarBody() throws IOException, CoreApiException {
+        String responseString = "\"true\"";
+        Exception exception = assertThrows(CoreApiException.class, () -> {
+            getApiCallGlobalErrorTemplate(responseString, 410).execute();
+        });
+        String expected = "Failed to make the request, true";
+        String actual = exception.getMessage().trim();
+        assertEquals(actual, expected);
+    }
+    
     /**
      * Test the Global Error template missing status code.
      * @throws IOException Signals that an I/O exception of some sort has occurred.
@@ -444,6 +488,10 @@ public class EndToEndTest extends MockCoreConfig {
         globalErrorCase.put("401",
                 ErrorCase.setTemplate("Failed to make the request, {$response.header.content-type} "
                         + "{$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
+                        (reason, context) -> new CoreApiException(reason, context)));
+
+        globalErrorCase.put("410",
+                ErrorCase.setTemplate("Failed to make the request, {$response.body}",
                         (reason, context) -> new CoreApiException(reason, context)));
 
         globalErrorCase.put("405",

--- a/src/test/java/apimatic/core/EndToEndTest.java
+++ b/src/test/java/apimatic/core/EndToEndTest.java
@@ -1,20 +1,25 @@
 package apimatic.core;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import apimatic.core.exceptions.GlobalTestException;
 import apimatic.core.mocks.MockCoreConfig;
 import io.apimatic.core.ApiCall;
+import io.apimatic.core.ErrorCase;
 import io.apimatic.core.GlobalConfiguration;
 import io.apimatic.core.types.CoreApiException;
 import io.apimatic.core.utilities.CoreHelper;
@@ -35,6 +40,10 @@ public class EndToEndTest extends MockCoreConfig {
      * Success code status code.
      */
     private static final int SUCCESS_CODE = 200;
+    private static final int BAD_REQUEST = 400;
+    private static final int TOO_MANY_REQUEST = 429;
+    private static final int UNAUTHORIZED = 401;
+    private static final int METHOD_NOT_ALLOWED = 405;
 
     /**
      * Initializes mocks annotated with Mock.
@@ -99,6 +108,174 @@ public class EndToEndTest extends MockCoreConfig {
         assertEquals(actual, expected);
     }
 
+
+    /**
+     * Test the local error template.
+     * @throws IOException Signals that an I/O exception of some sort has occurred.
+     * @throws CoreApiException Exception in api call execution.
+     */
+    @Test
+    public void testLocalErrorTemplateBody() throws IOException, CoreApiException {
+        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+                + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
+                + "      \"code\": \"UNAUTHORIZED\",\r\n"
+                + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
+                + "  ]\r\n" + "}\r\n" + "\r\n";
+        Exception exception = assertThrows(CoreApiException.class, () -> {
+            getApiCallLocalErrorTemplate(response, BAD_REQUEST).execute();
+        });
+        String expected =
+                "Failed to make the request, 400 UNAUTHORIZED - This request could not be authorized.";
+        String actual = exception.getMessage();
+        assertEquals(actual, expected);
+    }
+
+
+    /**
+     * Test the Global Error template.
+     * @throws IOException Signals that an I/O exception of some sort has occurred.
+     * @throws CoreApiException Exception in api call execution.
+     */
+    @Test
+    public void testGlobalErrorTemplateBody() throws IOException, CoreApiException {
+        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+                + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
+                + "      \"code\": \"UNAUTHORIZED\",\r\n"
+                + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
+                + "  ]\r\n" + "}\r\n" + "\r\n";
+        Exception exception = assertThrows(GlobalTestException.class, () -> {
+            getApiCallGlobalErrorTemplate(response, BAD_REQUEST).execute();
+        });
+        String expected =
+                "Failed to make the request, 400 UNAUTHORIZED - This request could not be authorized.";
+        String actual = exception.getMessage();
+        assertEquals(actual, expected);
+    }
+
+    /**
+     * Test the Global Error template.
+     * @throws IOException Signals that an I/O exception of some sort has occurred.
+     * @throws CoreApiException Exception in api call execution.
+     */
+    @Test
+    public void testGlobalErrorTemplateMissingBody() throws IOException, CoreApiException {
+        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+                + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
+                + "      \"code\": \"UNAUTHORIZED\"\r\n" + "    }\r\n" + "  ]\r\n" + "}\r\n"
+                + "\r\n";
+        Exception exception = assertThrows(GlobalTestException.class, () -> {
+            getApiCallGlobalErrorTemplate(response, BAD_REQUEST).execute();
+        });
+        String expected = "Failed to make the request, 400 UNAUTHORIZED - ";
+        String actual = exception.getMessage();
+        assertEquals(actual, expected);
+    }
+
+    /**
+     * Test the Global Error template missing status code.
+     * @throws IOException Signals that an I/O exception of some sort has occurred.
+     * @throws CoreApiException Exception in api call execution.
+     */
+    @Test
+    public void testGlobalErrorTemplateMissingStatusCode() throws IOException, CoreApiException {
+        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+                + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
+                + "      \"code\": \"UNAUTHORIZED\",\r\n"
+                + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
+                + "  ]\r\n" + "}\r\n" + "\r\n";
+        Exception exception = assertThrows(CoreApiException.class, () -> {
+            getApiCallGlobalErrorTemplate(response, TOO_MANY_REQUEST).execute();
+        });
+        String expected =
+                "Failed to make the request, UNAUTHORIZED - This request could not be authorized.";
+        String actual = exception.getMessage();
+        assertEquals(actual, expected);
+    }
+
+    /**
+     * Test the Global Error template headers.
+     * @throws IOException Signals that an I/O exception of some sort has occurred.
+     * @throws CoreApiException Exception in api call execution.
+     */
+    @Test
+    public void testGlobalErrorTemplateHeaders() throws IOException, CoreApiException {
+        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+                + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
+                + "      \"code\": \"UNAUTHORIZED\",\r\n"
+                + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
+                + "  ]\r\n" + "}\r\n" + "\r\n";
+        Exception exception = assertThrows(CoreApiException.class, () -> {
+            getApiCallGlobalErrorTemplateWithHeaders(response, UNAUTHORIZED).execute();
+        });
+        String expected =
+                "Failed to make the request, application/json UNAUTHORIZED - This request could not be authorized.";
+        String actual = exception.getMessage();
+        assertEquals(actual, expected);
+    }
+
+    /**
+     * Test the Global Error template missing headers.
+     * @throws IOException Signals that an I/O exception of some sort has occurred.
+     * @throws CoreApiException Exception in api call execution.
+     */
+    @Test
+    public void testGlobalErrorTemplateHeadersMissing() throws IOException, CoreApiException {
+        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+                + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
+                + "      \"code\": \"UNAUTHORIZED\",\r\n"
+                + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
+                + "  ]\r\n" + "}\r\n" + "\r\n";
+        Exception exception = assertThrows(CoreApiException.class, () -> {
+            getApiCallGlobalErrorTemplateWithHeaders(response, METHOD_NOT_ALLOWED).execute();
+        });
+        String expected =
+                "Failed to make the request,  UNAUTHORIZED - This request could not be authorized.";
+        String actual = exception.getMessage();
+        assertEquals(actual, expected);
+    }
+    
+    /**
+     * Test the Global Error template missing headers.
+     * @throws IOException Signals that an I/O exception of some sort has occurred.
+     * @throws CoreApiException Exception in api call execution.
+     */
+    @Test
+    public void testGlobalErrorTemplate4XX() throws IOException, CoreApiException {
+        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+                + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
+                + "      \"code\": \"UNAUTHORIZED\",\r\n"
+                + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
+                + "  ]\r\n" + "}\r\n" + "\r\n";
+        Exception exception = assertThrows(CoreApiException.class, () -> {
+            getApiCallGlobalErrorTemplateWithHeaders(response, 415).execute();
+        });
+        String expected =
+                "Failed to make the request, UNAUTHORIZED - This request could not be authorized.";
+        String actual = exception.getMessage();
+        assertEquals(actual, expected);
+    }
+    
+    /**
+     * Test the Global Error template missing headers.
+     * @throws IOException Signals that an I/O exception of some sort has occurred.
+     * @throws CoreApiException Exception in api call execution.
+     */
+    @Test
+    public void testGlobalErrorTemplate5XX() throws IOException, CoreApiException {
+        String response = "{\r\n" + "  \"errors\": [\r\n" + "    {\r\n"
+                + "      \"category\": \"AUTHENTICATION_ERROR\",\r\n"
+                + "      \"code\": \"UNAUTHORIZED\",\r\n"
+                + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
+                + "  ]\r\n" + "}\r\n" + "\r\n";
+        Exception exception = assertThrows(CoreApiException.class, () -> {
+            getApiCallGlobalErrorTemplateWithHeaders(response, 500).execute();
+        });
+        String expected =
+                "Failed to make the request, http status code: 500";
+        String actual = exception.getMessage();
+        assertEquals(actual, expected);
+    }
+
     private ApiCall<String, CoreApiException> getApiCall() throws IOException {
         when(response.getBody()).thenReturn("\"Turtle\"");
         return new ApiCall.Builder<String, CoreApiException>().globalConfig(getGlobalConfig())
@@ -117,18 +294,90 @@ public class EndToEndTest extends MockCoreConfig {
                         param -> param.arraySerializationFormat(ArraySerializationFormat.INDEXED)
                                 .hasBinaryResponse(false).retryOption(RetryOption.DEFAULT))
                 .build();
+    }
 
+    private ApiCall<String, CoreApiException> getApiCallLocalErrorTemplate(String responseString,
+            int statusCode) throws IOException {
+        when(response.getBody()).thenReturn(responseString);
+        when(response.getStatusCode()).thenReturn(statusCode);
+        return new ApiCall.Builder<String, CoreApiException>().globalConfig(getGlobalConfig())
+                .requestBuilder(requestBuilder -> requestBuilder.server("https://localhost:3000")
+                        .path("/v2/bank-accounts")
+                        .queryParam(param -> param.key("cursor").value("cursor").isRequired(false))
+                        .formParam(param -> param.key("limit").value("limit").isRequired(false))
+                        .templateParam(param -> param.key("location_id").value("locationId")
+                                .shouldEncode(true).isRequired(false))
+                        .headerParam(param -> param.key("accept").value("application/json"))
+                        .authenticationKey("global").httpMethod(Method.GET))
+                .responseHandler(responseHandler -> responseHandler
+                        .deserializer(response -> CoreHelper.deserialize(response, String.class))
+                        .localErrorCase("400", ErrorCase.createErrorTemplate(
+                                "Failed to make the request, {$statusCode} {$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
+                                (reason, context) -> new CoreApiException(reason, context)))
+                        .nullify404(false).globalErrorCase(Collections.emptyMap()))
+                .endpointConfiguration(
+                        param -> param.arraySerializationFormat(ArraySerializationFormat.INDEXED)
+                                .hasBinaryResponse(false).retryOption(RetryOption.DEFAULT))
+                .build();
+
+    }
+
+    private ApiCall<String, CoreApiException> getApiCallGlobalErrorTemplate(String responseString,
+            int statusCode) throws IOException {
+        when(response.getBody()).thenReturn(responseString);
+        when(response.getStatusCode()).thenReturn(statusCode);
+        return new ApiCall.Builder<String, CoreApiException>().globalConfig(getGlobalConfig())
+                .requestBuilder(requestBuilder -> requestBuilder.server("https://localhost:3000")
+                        .path("/v2/bank-accounts")
+                        .queryParam(param -> param.key("cursor").value("cursor").isRequired(false))
+                        .formParam(param -> param.key("limit").value("limit").isRequired(false))
+                        .templateParam(param -> param.key("location_id").value("locationId")
+                                .shouldEncode(true).isRequired(false))
+                        .headerParam(param -> param.key("accept").value("application/json"))
+                        .authenticationKey("global").httpMethod(Method.GET))
+                .responseHandler(responseHandler -> responseHandler
+                        .deserializer(response -> CoreHelper.deserialize(response, String.class))
+                        .nullify404(false).globalErrorCase(getGlobalErrorCases()))
+                .endpointConfiguration(
+                        param -> param.arraySerializationFormat(ArraySerializationFormat.INDEXED)
+                                .hasBinaryResponse(false).retryOption(RetryOption.DEFAULT))
+                .build();
+    }
+
+
+    private ApiCall<String, CoreApiException> getApiCallGlobalErrorTemplateWithHeaders(
+            String responseString, int statusCode) throws IOException {
+        when(response.getBody()).thenReturn(responseString);
+        when(response.getStatusCode()).thenReturn(statusCode);
+        when(response.getHeaders()).thenReturn(getHttpHeaders());
+        when(getHttpHeaders().has("content-type")).thenReturn(true);
+        when(getHttpHeaders().value("content-type")).thenReturn("application/json");
+        return new ApiCall.Builder<String, CoreApiException>().globalConfig(getGlobalConfig())
+                .requestBuilder(requestBuilder -> requestBuilder.server("https://localhost:3000")
+                        .path("/v2/bank-accounts")
+                        .queryParam(param -> param.key("cursor").value("cursor").isRequired(false))
+                        .formParam(param -> param.key("limit").value("limit").isRequired(false))
+                        .templateParam(param -> param.key("location_id").value("locationId")
+                                .shouldEncode(true).isRequired(false))
+                        .headerParam(param -> param.key("accept").value("application/json"))
+                        .authenticationKey("global").httpMethod(Method.GET))
+                .responseHandler(responseHandler -> responseHandler
+                        .deserializer(response -> CoreHelper.deserialize(response, String.class))
+                        .nullify404(false).globalErrorCase(getGlobalErrorCases()))
+                .endpointConfiguration(
+                        param -> param.arraySerializationFormat(ArraySerializationFormat.INDEXED)
+                                .hasBinaryResponse(false).retryOption(RetryOption.DEFAULT))
+                .build();
     }
 
     private GlobalConfiguration getGlobalConfig() {
         String userAgent = "APIMATIC 3.0";
-        GlobalConfiguration globalConfig =
-                new GlobalConfiguration.Builder().authentication(Collections.emptyMap())
-                        .compatibilityFactory(getCompatibilityFactory()).httpClient(httpClient)
-                        .baseUri(server -> getBaseUri(server)).callback(callback)
-                        .userAgent(userAgent).userAgentConfig(Collections.emptyMap())
-                        .additionalHeaders(null).globalHeader("version", "0.1")
-                        .globalHeader("version", "1.2").build();
+        GlobalConfiguration globalConfig = new GlobalConfiguration.Builder()
+                .authentication(Collections.emptyMap())
+                .compatibilityFactory(getCompatibilityFactory()).httpClient(httpClient)
+                .baseUri(server -> getBaseUri(server)).callback(callback).userAgent(userAgent)
+                .userAgentConfig(Collections.emptyMap()).additionalHeaders(null)
+                .globalHeader("version", "0.1").globalHeader("version", "1.2").build();
         return globalConfig;
     }
 
@@ -148,4 +397,38 @@ public class EndToEndTest extends MockCoreConfig {
         when(context.getResponse()).thenReturn(response);
         when(response.getStatusCode()).thenReturn(SUCCESS_CODE);
     }
+
+    private Map<String, ErrorCase<CoreApiException>> getGlobalErrorCases() {
+        Map<String, ErrorCase<CoreApiException>> globalErrorCase = new HashMap<>();
+        globalErrorCase.put("400", ErrorCase.createErrorTemplate(
+                "Failed to make the request, {$statusCode} {$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
+                (reason, context) -> new GlobalTestException(reason, context)));
+
+        globalErrorCase.put("404", ErrorCase.create("Not found",
+                (reason, context) -> new CoreApiException(reason, context)));
+
+        globalErrorCase.put("401", ErrorCase.createErrorTemplate(
+                "Failed to make the request, {$response.header.content-type} {$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
+                (reason, context) -> new CoreApiException(reason, context)));
+
+        globalErrorCase.put("405", ErrorCase.createErrorTemplate(
+                "Failed to make the request, {$response.header.accept} {$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
+                (reason, context) -> new CoreApiException(reason, context)));
+        
+        globalErrorCase.put("500", ErrorCase.createErrorTemplate(
+                "Failed to make the request, http status code: {$statusCode}",
+                (reason, context) -> new CoreApiException(reason, context)));
+        
+        globalErrorCase.put("4XX", ErrorCase.createErrorTemplate(
+                "Failed to make the request, {$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
+                (reason, context) -> new CoreApiException(reason, context)));
+
+        globalErrorCase.put(ErrorCase.DEFAULT, ErrorCase.create(
+                "Failed to make the request, {$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
+                (reason, context) -> new CoreApiException(reason, context)));
+
+        return globalErrorCase;
+
+    }
+
 }

--- a/src/test/java/apimatic/core/EndToEndTest.java
+++ b/src/test/java/apimatic/core/EndToEndTest.java
@@ -46,6 +46,7 @@ public class EndToEndTest extends MockCoreConfig {
     private static final int METHOD_NOT_ALLOWED = 405;
     private static final int UNSUPPORTED_MEDIA = 415;
     private static final int INTERNAL_SERVER_ERROR = 500;
+    private static final int GONE_CLIENT = 410;
 
     /**
      * Initializes mocks annotated with Mock.
@@ -212,7 +213,7 @@ public class EndToEndTest extends MockCoreConfig {
         String actual = exception.getMessage().trim();
         assertEquals(actual, expected);
     }
-    
+
     /**
      * Test the Global Error template.
      * @throws IOException Signals that an I/O exception of some sort has occurred.
@@ -228,7 +229,7 @@ public class EndToEndTest extends MockCoreConfig {
         String actual = exception.getMessage().trim();
         assertEquals(actual, expected);
     }
-    
+
     /**
      * Test the Global Error template.
      * @throws IOException Signals that an I/O exception of some sort has occurred.
@@ -238,13 +239,13 @@ public class EndToEndTest extends MockCoreConfig {
     public void testGlobalErrorTemplateExistScalarBody() throws IOException, CoreApiException {
         String responseString = "\"true\"";
         Exception exception = assertThrows(CoreApiException.class, () -> {
-            getApiCallGlobalErrorTemplate(responseString, 410).execute();
+            getApiCallGlobalErrorTemplate(responseString, GONE_CLIENT).execute();
         });
         String expected = "Failed to make the request, true";
         String actual = exception.getMessage().trim();
         assertEquals(actual, expected);
     }
-    
+
     /**
      * Test the Global Error template missing status code.
      * @throws IOException Signals that an I/O exception of some sort has occurred.

--- a/src/test/java/apimatic/core/EndToEndTest.java
+++ b/src/test/java/apimatic/core/EndToEndTest.java
@@ -44,6 +44,8 @@ public class EndToEndTest extends MockCoreConfig {
     private static final int TOO_MANY_REQUEST = 429;
     private static final int UNAUTHORIZED = 401;
     private static final int METHOD_NOT_ALLOWED = 405;
+    private static final int UNSUPPORTED_MEDIA = 415;
+    private static final int INTERNAL_SERVER_ERROR = 500;
 
     /**
      * Initializes mocks annotated with Mock.
@@ -247,7 +249,7 @@ public class EndToEndTest extends MockCoreConfig {
                 + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
                 + "  ]\r\n" + "}\r\n" + "\r\n";
         Exception exception = assertThrows(CoreApiException.class, () -> {
-            getApiCallGlobalErrorTemplateWithHeaders(responseString, 415).execute();
+            getApiCallGlobalErrorTemplateWithHeaders(responseString, UNSUPPORTED_MEDIA).execute();
         });
         String expected = "Failed to make the request, UNAUTHORIZED - "
                 + "This request could not be authorized.";
@@ -268,7 +270,8 @@ public class EndToEndTest extends MockCoreConfig {
                 + "      \"detail\": \"This request could not be authorized.\"\r\n" + "    }\r\n"
                 + "  ]\r\n" + "}\r\n" + "\r\n";
         Exception exception = assertThrows(CoreApiException.class, () -> {
-            getApiCallGlobalErrorTemplateWithHeaders(responseString, 500).execute();
+            getApiCallGlobalErrorTemplateWithHeaders(responseString, INTERNAL_SERVER_ERROR)
+                    .execute();
         });
         String expected = "Failed to make the request, http status code: 500";
         String actual = exception.getMessage();

--- a/src/test/java/apimatic/core/ResponseHandlerTest.java
+++ b/src/test/java/apimatic/core/ResponseHandlerTest.java
@@ -327,7 +327,7 @@ public class ResponseHandlerTest extends MockCoreConfig {
         ResponseHandler<String, CoreApiException> coreResponseHandler =
                 new ResponseHandler.Builder<String, CoreApiException>()
                         .localErrorCase("403",
-                                ErrorCase.create("Forbidden",
+                                ErrorCase.setReason("Forbidden",
                                         (reason, context) -> new CoreApiException(reason, context)))
                         .build();
         // stub
@@ -349,7 +349,7 @@ public class ResponseHandlerTest extends MockCoreConfig {
         ResponseHandler<String, CoreApiException> coreResponseHandler =
                 new ResponseHandler.Builder<String, CoreApiException>()
                         .localErrorCase("403",
-                                ErrorCase.create("Forbidden",
+                                ErrorCase.setReason("Forbidden",
                                         (reason, context) -> new CoreApiException(reason, context)))
                         .globalErrorCase(getGlobalErrorCases()).build();
 
@@ -373,7 +373,7 @@ public class ResponseHandlerTest extends MockCoreConfig {
         ResponseHandler<String, CoreApiException> coreResponseHandler =
                 new ResponseHandler.Builder<String, CoreApiException>()
                         .localErrorCase("403",
-                                ErrorCase.create("Forbidden",
+                                ErrorCase.setReason("Forbidden",
                                         (reason, context) -> new CoreApiException(reason, context)))
                         .globalErrorCase(getGlobalErrorCases()).build();
 
@@ -441,13 +441,13 @@ public class ResponseHandlerTest extends MockCoreConfig {
     private Map<String, ErrorCase<CoreApiException>> getGlobalErrorCases() {
 
         Map<String, ErrorCase<CoreApiException>> globalErrorCase = new HashMap<>();
-        globalErrorCase.put("400", ErrorCase.create("Bad Request",
+        globalErrorCase.put("400", ErrorCase.setReason("Bad Request",
                 (reason, context) -> new GlobalTestException(reason, context)));
 
-        globalErrorCase.put("404", ErrorCase.create("Not found",
+        globalErrorCase.put("404", ErrorCase.setReason("Not found",
                 (reason, context) -> new CoreApiException(reason, context)));
 
-        globalErrorCase.put(ErrorCase.DEFAULT, ErrorCase.create("Invalid response.",
+        globalErrorCase.put(ErrorCase.DEFAULT, ErrorCase.setReason("Invalid response.",
                 (reason, context) -> new CoreApiException(reason, context)));
 
         return globalErrorCase;


### PR DESCRIPTION
Exception from the server is significant. From server exception, we can take critical decisions. If the exception message from the server is not self-explanatory then it is hard for a client to respond accordingly.  We noticed that we can improve the message thrown to the client from the server.  Now, the client will register an error template against a particular code.  On throwing an exception, the core library will replace the placeholder using JsonPointer.  The user will get the proper message that he wanted.

closes #52