### PR TITLE
fix(gradle-build): fix the build issue of gradle project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
 			<groupId>org.jacoco</groupId>
 			<artifactId>jacoco-maven-plugin</artifactId>
 			<version>0.8.5</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
The core library must be compiled with the Gradle project. So. I limit the scope of jococo to test because it was not resolving.

closes #54