### PR TITLE
ci(update-release-script): fix failing delete intermediate branch step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         uses: devops-infra/action-commit-push@master
         with:
            github_token: "${{ secrets.GITHUB_TOKEN }}"
-           commit_message: "ci(release-version): update pom.xml [ci skip]"
+           commit_message: "ci(release-version) update pom.xml [ci skip]"
            force: false
            target_branch: project-version-update
       - name: Push the version change

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,9 @@ jobs:
            branch: main
       - name: Delete the intermediate branch
         if: steps.release.outputs.exit_code == 0
-        uses: dawidd6/action-delete-branch@v3
-        with:
-          github_token: ${{github.token}}
-          branches: project-version-update
+        run: |
+           git branch -D project-version-update &>/dev/null || true
+           git push origin :project-version-update &>/dev/null || true
       - name: Create tag
         if: steps.release.outputs.exit_code == 0
         id: tag_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Release To Maven Central
-run-name: ${{ github.event.inputs.Title }} (${{ github.event.inputs.Version }})
+run-name: Release ${{ github.event.inputs.Version }}
 # Run workflow on commits to the `main` branch
 on:
    workflow_dispatch:
@@ -8,10 +8,6 @@ on:
         description: "Version to be released in format: x.y.z, where x => major version, y => minor version and z => patch version"
         required: true
         default: "0.1.0"
-      Title:
-        description: "Title of the release"
-        required: true
-        default: "Improving API developer experience"
 
 jobs:
   publish:
@@ -70,5 +66,5 @@ jobs:
         uses: ncipollo/release-action@v1
         with: 
           tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: Release ${{ github.event.inputs.Title }}
+          name: Version ${{ github.event.inputs.Version }}
           body: ${{ steps.tag_version.outputs.changelog }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Release To Maven Central
-
+run-name: ${{ github.event.inputs.Title }} (${{ github.event.inputs.Version }})
 # Run workflow on commits to the `main` branch
 on:
    workflow_dispatch:


### PR DESCRIPTION
The following PR fixes the release action failing on the delete intermediate branch if the user has already updated the pom.xml version in the PR. This also fixes the addition of an updated ci version message being added to the release notes.

Closes #67
Closes #57 