### PR TITLE
feat(opt-null-equals): override equals in optional-nullable wrapper

### DIFF
--- a/src/main/java/io/apimatic/core/types/OptionalNullable.java
+++ b/src/main/java/io/apimatic/core/types/OptionalNullable.java
@@ -59,14 +59,19 @@ public final class OptionalNullable<T> {
     }
 
     @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) {
             return true;
         }
         if (obj instanceof OptionalNullable<?>) {
-            return Objects.equals(((OptionalNullable<?>) obj).value, this.value);
+            return Objects.equals(((OptionalNullable<?>) obj).value, value);
         }
-        return Objects.equals(obj, this.value);
+        return Objects.equals(obj, value);
     }
 
     /**

--- a/src/main/java/io/apimatic/core/types/OptionalNullable.java
+++ b/src/main/java/io/apimatic/core/types/OptionalNullable.java
@@ -68,9 +68,11 @@ public final class OptionalNullable<T> {
         if (obj == this) {
             return true;
         }
+
         if (obj instanceof OptionalNullable<?>) {
             return Objects.equals(((OptionalNullable<?>) obj).value, value);
         }
+
         return Objects.equals(obj, value);
     }
 

--- a/src/main/java/io/apimatic/core/types/OptionalNullable.java
+++ b/src/main/java/io/apimatic/core/types/OptionalNullable.java
@@ -5,9 +5,12 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+
 import io.apimatic.core.utilities.LocalDateTimeHelper;
 
 /**
@@ -53,6 +56,17 @@ public final class OptionalNullable<T> {
      */
     public static <T> T getFrom(OptionalNullable<T> optionalNullable) {
         return (optionalNullable == null) ? null : optionalNullable.value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof OptionalNullable<?>) {
+            return Objects.equals(((OptionalNullable<?>) obj).value, this.value);
+        }
+        return Objects.equals(obj, this.value);
     }
 
     /**

--- a/src/test/java/apimatic/core/type/OptionalNullableTest.java
+++ b/src/test/java/apimatic/core/type/OptionalNullableTest.java
@@ -96,11 +96,18 @@ public class OptionalNullableTest {
      * An instance of {@link LocalDateTime}.
      */
     private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.of(2021, 1, 20, 12, 12, 41);
-
     /**
      * An instance of {@link LocalDate}.
      */
     private static final LocalDate LOCAL_DATE = LocalDate.of(2020, 1, 8);
+    /**
+     * An instance of a number.
+     */
+    private static final int NUMBER_124 = 124;
+    /**
+     * An instance of a number.
+     */
+    private static final int NUMBER_125 = 125;
 
     @Test
     public void testSimpleDate() throws IOException {
@@ -268,29 +275,26 @@ public class OptionalNullableTest {
         OptionalNullable<String> object1 = OptionalNullable.of("some string");
         OptionalNullable<String> object2 = OptionalNullable.of("some string");
         OptionalNullable<String> object3 = OptionalNullable.of("some other string");
-        int number = 124;
-        OptionalNullable<Integer> object4 = OptionalNullable.of(number);
+        OptionalNullable<Integer> object4 = OptionalNullable.of(NUMBER_124);
 
         assertTrue(object1.equals(object1));
         assertTrue(object1.equals(object2));
         assertTrue(object1.equals("some string"));
-        assertTrue(object4.equals(number));
+        assertTrue(object4.equals(NUMBER_124));
 
         assertFalse(object1.equals(object3));
         assertFalse(object1.equals(object4));
-        int numberWrong = 125;
-        assertFalse(object4.equals(numberWrong));
+        assertFalse(object4.equals(NUMBER_125));
     }
 
     @Test
     public void testHashCode() throws IOException {
         OptionalNullable<String> object1 = OptionalNullable.of("some string");
         OptionalNullable<String> object2 = OptionalNullable.of("some string");
-        int number = 124;
-        OptionalNullable<Integer> object3 = OptionalNullable.of(number);
+        OptionalNullable<Integer> object3 = OptionalNullable.of(NUMBER_124);
 
         assertEquals(object1.hashCode(), object2.hashCode());
         assertEquals(object1.hashCode(), Objects.hash("some string"));
-        assertEquals(object3.hashCode(), Objects.hash(number));
+        assertEquals(object3.hashCode(), Objects.hash(NUMBER_124));
     }
 }

--- a/src/test/java/apimatic/core/type/OptionalNullableTest.java
+++ b/src/test/java/apimatic/core/type/OptionalNullableTest.java
@@ -1,6 +1,9 @@
 package apimatic.core.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -21,11 +24,11 @@ import apimatic.core.models.SimpleDateMap;
 import apimatic.core.models.UnixDate;
 import apimatic.core.models.UnixDateArray;
 import apimatic.core.models.UnixDateMap;
+import io.apimatic.core.types.OptionalNullable;
 import io.apimatic.core.utilities.CoreHelper;
 import io.apimatic.core.utilities.LocalDateTimeHelper;
 
 public class OptionalNullableTest {
-
 
     /**
      * Simple date string.
@@ -256,5 +259,22 @@ public class OptionalNullableTest {
 
         String actual = rfc8601DateMap.toString();
         assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testEquals() throws IOException {
+        OptionalNullable<String> object1 = OptionalNullable.of("some string");
+        OptionalNullable<String> object2 = OptionalNullable.of("some string");
+        OptionalNullable<String> object3 = OptionalNullable.of("some other string");
+        OptionalNullable<Integer> object4 = OptionalNullable.of(124);
+
+        assertTrue(object1.equals(object1));
+        assertTrue(object1.equals(object2));
+        assertTrue(object1.equals("some string"));
+        assertTrue(object4.equals(124));
+
+        assertFalse(object1.equals(object3));
+        assertFalse(object1.equals(object4));
+        assertFalse(object4.equals(125));
     }
 }

--- a/src/test/java/apimatic/core/type/OptionalNullableTest.java
+++ b/src/test/java/apimatic/core/type/OptionalNullableTest.java
@@ -11,6 +11,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
 import org.junit.Test;
 import apimatic.core.models.Rfc1123Date;
 import apimatic.core.models.Rfc1123DateArray;
@@ -266,15 +268,29 @@ public class OptionalNullableTest {
         OptionalNullable<String> object1 = OptionalNullable.of("some string");
         OptionalNullable<String> object2 = OptionalNullable.of("some string");
         OptionalNullable<String> object3 = OptionalNullable.of("some other string");
-        OptionalNullable<Integer> object4 = OptionalNullable.of(124);
+        int number = 124;
+        OptionalNullable<Integer> object4 = OptionalNullable.of(number);
 
         assertTrue(object1.equals(object1));
         assertTrue(object1.equals(object2));
         assertTrue(object1.equals("some string"));
-        assertTrue(object4.equals(124));
+        assertTrue(object4.equals(number));
 
         assertFalse(object1.equals(object3));
         assertFalse(object1.equals(object4));
-        assertFalse(object4.equals(125));
+        int numberWrong = 125;
+        assertFalse(object4.equals(numberWrong));
+    }
+
+    @Test
+    public void testHashCode() throws IOException {
+        OptionalNullable<String> object1 = OptionalNullable.of("some string");
+        OptionalNullable<String> object2 = OptionalNullable.of("some string");
+        int number = 124;
+        OptionalNullable<Integer> object3 = OptionalNullable.of(number);
+
+        assertEquals(object1.hashCode(), object2.hashCode());
+        assertEquals(object1.hashCode(), Objects.hash("some string"));
+        assertEquals(object3.hashCode(), Objects.hash(number));
     }
 }

--- a/src/test/java/apimatic/core/type/OptionalNullableTest.java
+++ b/src/test/java/apimatic/core/type/OptionalNullableTest.java
@@ -276,15 +276,18 @@ public class OptionalNullableTest {
         OptionalNullable<String> object2 = OptionalNullable.of("some string");
         OptionalNullable<String> object3 = OptionalNullable.of("some other string");
         OptionalNullable<Integer> object4 = OptionalNullable.of(NUMBER_124);
+        OptionalNullable<Integer> object5 = OptionalNullable.of(null);
 
         assertTrue(object1.equals(object1));
         assertTrue(object1.equals(object2));
         assertTrue(object1.equals("some string"));
         assertTrue(object4.equals(NUMBER_124));
-
+        assertTrue(object5.equals(null));
+        
         assertFalse(object1.equals(object3));
         assertFalse(object1.equals(object4));
         assertFalse(object4.equals(NUMBER_125));
+        assertFalse(object1.equals(null));
     }
 
     @Test

--- a/src/test/java/apimatic/core/type/OptionalNullableTest.java
+++ b/src/test/java/apimatic/core/type/OptionalNullableTest.java
@@ -283,7 +283,7 @@ public class OptionalNullableTest {
         assertTrue(object1.equals("some string"));
         assertTrue(object4.equals(NUMBER_124));
         assertTrue(object5.equals(null));
-        
+
         assertFalse(object1.equals(object3));
         assertFalse(object1.equals(object4));
         assertFalse(object4.equals(NUMBER_125));


### PR DESCRIPTION
This PR overrides the original equals method for OptionalNullable class and added a new unit test for line coverage.

Closes #71 