### PR TITLE
fix(zoned-date-time): removed zoneId from serialized rfc8601 datetime string

### DIFF
--- a/src/main/java/io/apimatic/core/utilities/ZonedDateTimeHelper.java
+++ b/src/main/java/io/apimatic/core/utilities/ZonedDateTimeHelper.java
@@ -245,7 +245,7 @@ public class ZonedDateTimeHelper extends DateHelper {
      * @return The converted String.
      */
     public static String toRfc8601DateTime(ZonedDateTime value) {
-        return value == null ? null : value.toString();
+        return value == null ? null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(value);
     }
 
     /**

--- a/src/main/java/io/apimatic/core/utilities/ZonedDateTimeHelper.java
+++ b/src/main/java/io/apimatic/core/utilities/ZonedDateTimeHelper.java
@@ -236,7 +236,7 @@ public class ZonedDateTimeHelper extends DateHelper {
      * @return The parsed DateTime object.
      */
     public static ZonedDateTime fromRfc8601DateTime(String date) {
-        return ZonedDateTime.parse(date, DateTimeFormatter.ISO_DATE_TIME);
+        return ZonedDateTime.parse(date, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
     }
 
     /**

--- a/src/test/java/apimatic/core/type/OptionalNullableTest.java
+++ b/src/test/java/apimatic/core/type/OptionalNullableTest.java
@@ -83,20 +83,20 @@ public class OptionalNullableTest {
      */
     private static final String RFC8601_DATE =
             "{\"dateTime1\":null,\"dateTime\":\"2021-01-20T12:12:41Z\""
-            + ",\"zonedDateTime\":\"2021-01-20T12:12:41Z[GMT]\"}";
+            + ",\"zonedDateTime\":\"2021-01-20T12:12:41Z\"}";
     /**
      * RFC 8601 date array string.
      */
     private static final String RFC8601_DATE_ARRAY =
             "{\"dateTime1\":null,\"dateTime\":[\"2021-01-20T12:12:41Z\""
             + ",\"2021-01-20T12:12:41Z\"],\"zonedDateTime\":["
-            + "\"2021-01-20T12:12:41Z[GMT]\",\"2021-01-20T12:12:41Z[GMT]\"]}";
+            + "\"2021-01-20T12:12:41Z\",\"2021-01-20T12:12:41Z\"]}";
     /**
      * RFC 8601 date map string.
      */
     private static final String RFC8601_DATE_MAP =
             "{\"dateTime1\":null,\"dateTime\":{\"key\":\"2021-01-20T12:12:41Z\"}"
-            + ",\"zonedDateTime\":{\"key\":\"2021-01-20T12:12:41Z[GMT]\"}}";
+            + ",\"zonedDateTime\":{\"key\":\"2021-01-20T12:12:41Z\"}}";
     /**
      * RFC 8601 map to string.
      */

--- a/src/test/java/apimatic/core/utilities/XmlZonedDateTimeHelperTest.java
+++ b/src/test/java/apimatic/core/utilities/XmlZonedDateTimeHelperTest.java
@@ -20,7 +20,7 @@ public class XmlZonedDateTimeHelperTest {
         String rootName = "XmlRootName";
 
         // stub
-        String expected = "<XmlRootName>1997-07-13T06:10Z[GMT]</XmlRootName>";
+        String expected = "<XmlRootName>1997-07-13T06:10:00Z</XmlRootName>";
         String actual = XmlZonedDateTimeHelper.serializeRfc8601DateTime(zonedDateTime, rootName);
 
         assertEquals(actual, expected);

--- a/src/test/java/apimatic/core/utilities/XmlZonedDateTimeHelperTest.java
+++ b/src/test/java/apimatic/core/utilities/XmlZonedDateTimeHelperTest.java
@@ -28,14 +28,14 @@ public class XmlZonedDateTimeHelperTest {
 
     @Test
     public void testDeserializeRfc8601DateTime() {
-        String zonedDateTime = "<XmlRootName>1997-07-13T06:10Z[GMT]</XmlRootName>";
+        String zonedDateTime = "<XmlRootName>1997-07-13T06:10Z</XmlRootName>";
 
         // stub
         ZonedDateTime expected =
                 ZonedDateTime.of(YEAR1997, JULY, DAY13, HOUR6, MINUTES10, 0, 0, ZoneId.of("GMT"));
         ZonedDateTime actual = XmlZonedDateTimeHelper.deserializeRfc8601DateTime(zonedDateTime);
 
-        assertEquals(actual, expected);
+        assertEquals(expected.toEpochSecond(), actual.toEpochSecond());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/apimatic/core/utilities/ZonedDateTimeHelperTest.java
+++ b/src/test/java/apimatic/core/utilities/ZonedDateTimeHelperTest.java
@@ -450,11 +450,11 @@ public class ZonedDateTimeHelperTest {
 
     @Test
     public void testFromRfc8601String() {
-        String date = "1997-07-13T01:10Z[GMT]";
+        String date = "1997-07-13T01:10Z";
         LocalDateTime dateTime = LocalDateTime.of(YEAR1997, JULY, DAY13, 1, MINUTES10);
         ZonedDateTime expected = dateTime.atZone(ZoneId.of("GMT"));
         ZonedDateTime actualValue = ZonedDateTimeHelper.fromRfc8601DateTime(date);
-        assertEquals(actualValue, expected);
+        assertEquals(expected.toEpochSecond(), actualValue.toEpochSecond());
     }
 
 
@@ -522,7 +522,7 @@ public class ZonedDateTimeHelperTest {
         module.addDeserializer(ZonedDateTime.class, deserializer);
         mapper.registerModule(module);
 
-        String dateTime = "\"1997-07-13T06:10+05:00[Asia/Karachi]\"";
+        String dateTime = "\"1997-07-13T06:10:00+05:00\"";
 
         LocalDateTime localDateTime = LocalDateTime.of(YEAR1997, JULY, DAY13, 1, MINUTES10);
         ZonedDateTime expected = localDateTime.atZone(ZoneId.of("GMT"));

--- a/src/test/java/apimatic/core/utilities/ZonedDateTimeHelperTest.java
+++ b/src/test/java/apimatic/core/utilities/ZonedDateTimeHelperTest.java
@@ -42,7 +42,6 @@ public class ZonedDateTimeHelperTest {
         String actual = ZonedDateTimeHelper.toRfc1123DateTime(zonedDateTime);
         assertEquals(actual, expected);
     }
-
     @Test
     public void testZonedDateTimeNullToRfc1123() {
         ZonedDateTime dateTime = null;
@@ -135,7 +134,7 @@ public class ZonedDateTimeHelperTest {
         ZonedDateTime dateTime =
                 ZonedDateTime.of(YEAR1997, JULY, DAY13, HOUR6, MINUTES10, 0, 0, ZoneId.of("GMT"));
         // stub
-        String expected = "1997-07-13T06:10Z[GMT]";
+        String expected = "1997-07-13T06:10:00Z";
         String actual = ZonedDateTimeHelper.toRfc8601DateTime(dateTime);
         assertEquals(actual, expected);
     }
@@ -157,7 +156,7 @@ public class ZonedDateTimeHelperTest {
         List<ZonedDateTime> dateTimeArray = Arrays.asList(zonedDateTime1, zonedDateTime2);
 
         // stub
-        List<String> expected = Arrays.asList("2000-07-13T06:10Z[GMT]", "2020-07-25T06:10Z[GMT]");
+        List<String> expected = Arrays.asList("2000-07-13T06:10:00Z", "2020-07-25T06:10:00Z");
         List<String> actual = ZonedDateTimeHelper.toRfc8601DateTime(dateTimeArray);
 
         assertEquals(actual, expected);
@@ -182,8 +181,8 @@ public class ZonedDateTimeHelperTest {
 
         // stub
         Map<String, String> expected = new HashMap<>();
-        expected.put("dateTime1", "2000-07-13T06:10Z[GMT]");
-        expected.put("dateTime2", "2020-07-25T06:10Z[GMT]");
+        expected.put("dateTime1", "2000-07-13T06:10:00Z");
+        expected.put("dateTime2", "2020-07-25T06:10:00Z");
 
         assertEquals(ZonedDateTimeHelper.toRfc8601DateTime(dateTimeMap), expected);
     }
@@ -202,8 +201,8 @@ public class ZonedDateTimeHelperTest {
 
         // stub
         Map<String, String> mapOfStirng = new HashMap<>();
-        mapOfStirng.put("dateTime1", "2000-07-13T06:10Z[GMT]");
-        mapOfStirng.put("dateTime2", "2020-07-25T06:10Z[GMT]");
+        mapOfStirng.put("dateTime1", "2000-07-13T06:10:00Z");
+        mapOfStirng.put("dateTime2", "2020-07-25T06:10:00Z");
 
         List<Map<String, String>> expected = Arrays.asList(mapOfStirng);
 
@@ -506,7 +505,7 @@ public class ZonedDateTimeHelperTest {
         module.addSerializer(zonedDateTime.getClass(), serializer);
         mapper.registerModule(module);
 
-        String expected = "\"1997-07-13T01:10Z[GMT]\"";
+        String expected = "\"1997-07-13T01:10:00Z\"";
 
         String actual = mapper.writeValueAsString(zonedDateTime);
 


### PR DESCRIPTION
## What
This PR removed the ZoneId from the serialized string of rfc8601 datetime string format

## Why
We need to fix the serialized datetime string to its correct format

Closes #86 
 
## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [x] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
