### PR TITLE
fix(dynamic-error): removed side effects to keep error cases consistent

### DIFF
--- a/src/main/java/io/apimatic/core/ErrorCase.java
+++ b/src/main/java/io/apimatic/core/ErrorCase.java
@@ -96,10 +96,10 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
         if (!isErrorTemplate) {
             return reason;
         }
-        String newReason = replaceStatusCodeFromTemplate(response.getStatusCode(), this.reason);
-        newReason = replaceHeadersFromTemplate(response.getHeaders(), newReason);
-        newReason = replaceBodyFromTemplate(response.getBody(), newReason);
-        return newReason;
+        String resolvedReason = replaceStatusCodeFromTemplate(response.getStatusCode(), reason);
+        resolvedReason = replaceHeadersFromTemplate(response.getHeaders(), resolvedReason);
+        resolvedReason = replaceBodyFromTemplate(response.getBody(), resolvedReason);
+        return resolvedReason;
     }
 
     private String replaceStatusCodeFromTemplate(int statusCode, String reason) {

--- a/src/main/java/io/apimatic/core/ErrorCase.java
+++ b/src/main/java/io/apimatic/core/ErrorCase.java
@@ -96,10 +96,10 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
         if (!isErrorTemplate) {
             return reason;
         }
-        String reason = replaceStatusCodeFromTemplate(response.getStatusCode(), this.reason);
-        reason = replaceHeadersFromTemplate(response.getHeaders(), reason);
-        reason = replaceBodyFromTemplate(response.getBody(), reason);
-        return reason;
+        String newReason = replaceStatusCodeFromTemplate(response.getStatusCode(), this.reason);
+        newReason = replaceHeadersFromTemplate(response.getHeaders(), newReason);
+        newReason = replaceBodyFromTemplate(response.getBody(), newReason);
+        return newReason;
     }
 
     private String replaceStatusCodeFromTemplate(int statusCode, String reason) {
@@ -154,7 +154,7 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
             String pointerKey = key;
             replaceBodyString(responseBody, formatter, jsonStructure, key, pointerKey);
         }
-        return formatter.toString().replaceAll("\"", "");
+        return formatter.toString().replace("\"", "");
     }
 
     private void replaceBodyString(String responseBody, StringBuilder formatter,

--- a/src/main/java/io/apimatic/core/ErrorCase.java
+++ b/src/main/java/io/apimatic/core/ErrorCase.java
@@ -59,10 +59,7 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
      * @throws ExceptionType Represents error response from the server.
      */
     public void throwException(Context httpContext) throws ExceptionType {
-        if (isErrorTemplate) {
-            replacePlaceHolder(httpContext.getResponse());
-        }
-        throw exceptionCreator.apply(reason, httpContext);
+        throw exceptionCreator.apply(getReason(httpContext.getResponse()), httpContext);
     }
 
     /**
@@ -95,13 +92,33 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
         return new ErrorCase<ExceptionType>(reason, exceptionCreator, true);
     }
 
-    private void replacePlaceHolder(Response response) {
-        replaceStatusCodeFromTemplate(response.getStatusCode());
-        replaceHeadersFromTemplate(response.getHeaders());
-        replaceBodyFromTemplate(response.getBody());
+    private String getReason(Response response) {
+        if (!isErrorTemplate) {
+            return reason;
+        }
+        String reason = replaceStatusCodeFromTemplate(response.getStatusCode(), this.reason);
+        reason = replaceHeadersFromTemplate(response.getHeaders(), reason);
+        reason = replaceBodyFromTemplate(response.getBody(), reason);
+        return reason;
     }
 
-    private void replaceHeadersFromTemplate(HttpHeaders headers) {
+    private String replaceStatusCodeFromTemplate(int statusCode, String reason) {
+        StringBuilder formatter = new StringBuilder(reason);
+        Matcher matcher = Pattern.compile("\\{(.*?)\\}").matcher(reason);
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            if (key.equals("$statusCode")) {
+                String formatKey = String.format("{%s}", key);
+                int index = formatter.indexOf(formatKey);
+                if (index != -1) {
+                    formatter.replace(index, index + formatKey.length(), "" + statusCode);
+                }
+            }
+        }
+        return formatter.toString();
+    }
+
+    private String replaceHeadersFromTemplate(HttpHeaders headers, String reason) {
         StringBuilder formatter = new StringBuilder(reason);
         Matcher matcher = Pattern.compile("\\{(.*?)\\}").matcher(reason);
         while (matcher.find()) {
@@ -118,10 +135,10 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
                 }
             }
         }
-        reason = formatter.toString();
+        return formatter.toString();
     }
 
-    private void replaceBodyFromTemplate(String responseBody) {
+    private String replaceBodyFromTemplate(String responseBody, String reason) {
         StringBuilder formatter = new StringBuilder(reason);
         JsonReader jsonReader = Json.createReader(new StringReader(responseBody));
         JsonStructure jsonStructure = null;
@@ -137,7 +154,7 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
             String pointerKey = key;
             replaceBodyString(responseBody, formatter, jsonStructure, key, pointerKey);
         }
-        reason = formatter.toString().replaceAll("\"", "");
+        return formatter.toString().replaceAll("\"", "");
     }
 
     private void replaceBodyString(String responseBody, StringBuilder formatter,
@@ -173,21 +190,5 @@ public final class ErrorCase<ExceptionType extends CoreApiException> {
             }
         }
         return toReplaceString;
-    }
-
-    private void replaceStatusCodeFromTemplate(int statusCode) {
-        StringBuilder formatter = new StringBuilder(reason);
-        Matcher matcher = Pattern.compile("\\{(.*?)\\}").matcher(reason);
-        while (matcher.find()) {
-            String key = matcher.group(1);
-            if (key.equals("$statusCode")) {
-                String formatKey = String.format("{%s}", key);
-                int index = formatter.indexOf(formatKey);
-                if (index != -1) {
-                    formatter.replace(index, index + formatKey.length(), "" + statusCode);
-                }
-            }
-        }
-        reason = formatter.toString();
     }
 }

--- a/src/test/java/apimatic/core/EndToEndTest.java
+++ b/src/test/java/apimatic/core/EndToEndTest.java
@@ -51,7 +51,7 @@ public class EndToEndTest extends MockCoreConfig {
     /**
      * Map of Global Error Cases
      */
-    private static final Map<String, ErrorCase<CoreApiException>> globalErrorCases =
+    private static final Map<String, ErrorCase<CoreApiException>> GLOBAL_ERROR_CASES =
             new HashMap<String, ErrorCase<CoreApiException>>() {
         private static final long serialVersionUID = 1L;
         {
@@ -456,7 +456,7 @@ public class EndToEndTest extends MockCoreConfig {
                         .authenticationKey("global").httpMethod(Method.GET))
                 .responseHandler(responseHandler -> responseHandler
                         .deserializer(response -> CoreHelper.deserialize(response, String.class))
-                        .nullify404(false).globalErrorCase(globalErrorCases))
+                        .nullify404(false).globalErrorCase(GLOBAL_ERROR_CASES))
                 .endpointConfiguration(
                         param -> param.arraySerializationFormat(ArraySerializationFormat.INDEXED)
                                 .hasBinaryResponse(false).retryOption(RetryOption.DEFAULT))
@@ -482,7 +482,7 @@ public class EndToEndTest extends MockCoreConfig {
                         .authenticationKey("global").httpMethod(Method.GET))
                 .responseHandler(responseHandler -> responseHandler
                         .deserializer(response -> CoreHelper.deserialize(response, String.class))
-                        .nullify404(false).globalErrorCase(globalErrorCases))
+                        .nullify404(false).globalErrorCase(GLOBAL_ERROR_CASES))
                 .endpointConfiguration(
                         param -> param.arraySerializationFormat(ArraySerializationFormat.INDEXED)
                                 .hasBinaryResponse(false).retryOption(RetryOption.DEFAULT))

--- a/src/test/java/apimatic/core/EndToEndTest.java
+++ b/src/test/java/apimatic/core/EndToEndTest.java
@@ -49,6 +49,47 @@ public class EndToEndTest extends MockCoreConfig {
     private static final int GONE_CLIENT = 410;
 
     /**
+     * Map of Global Error Cases
+     */
+    private static final Map<String, ErrorCase<CoreApiException>> globalErrorCases =
+            new HashMap<String, ErrorCase<CoreApiException>>() {
+        private static final long serialVersionUID = 1L;
+        {
+            put("400", ErrorCase.setTemplate(
+                    "Failed to make the request, {$statusCode} {$response.body#/errors/0/code} - "
+                            + "{$response.body#/errors/0/detail}",
+                    (reason, context) -> new GlobalTestException(reason, context)));
+            put("404", ErrorCase.setReason("Not found",
+                    (reason, context) -> new CoreApiException(reason, context)));
+            put("401",
+                    ErrorCase.setTemplate("Failed to make the request, "
+                            + "{$response.header.content-type} {$response.body#/errors/0/code}"
+                            + " - {$response.body#/errors/0/detail}",
+                            (reason, context) -> new CoreApiException(reason, context)));
+            put("410",
+                    ErrorCase.setTemplate("Failed to make the request, {$response.body}",
+                            (reason, context) -> new CoreApiException(reason, context)));
+            put("405",
+                    ErrorCase.setTemplate("Failed to make the request, {$response.header.accept} "
+                            + "{$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
+                            (reason, context) -> new CoreApiException(reason, context)));
+            put("500",
+                    ErrorCase.setTemplate("Failed to make the request, http status code:"
+                            + " {$statusCode}",
+                            (reason, context) -> new CoreApiException(reason, context)));
+            put("4XX",
+                    ErrorCase.setTemplate(
+                            "Failed to make the request, {$response.body#/errors/0/code}"
+                                    + " - {$response.body#/errors/0/detail}",
+                            (reason, context) -> new CoreApiException(reason, context)));
+            put(ErrorCase.DEFAULT,
+                    ErrorCase.setReason(
+                            "Failed to make the request, {$response.body#/errors/0/code}"
+                                    + " - {$response.body#/errors/0/detail}",
+                            (reason, context) -> new CoreApiException(reason, context)));
+        }};
+
+    /**
      * Initializes mocks annotated with Mock.
      */
     @Rule
@@ -415,7 +456,7 @@ public class EndToEndTest extends MockCoreConfig {
                         .authenticationKey("global").httpMethod(Method.GET))
                 .responseHandler(responseHandler -> responseHandler
                         .deserializer(response -> CoreHelper.deserialize(response, String.class))
-                        .nullify404(false).globalErrorCase(getGlobalErrorCases()))
+                        .nullify404(false).globalErrorCase(globalErrorCases))
                 .endpointConfiguration(
                         param -> param.arraySerializationFormat(ArraySerializationFormat.INDEXED)
                                 .hasBinaryResponse(false).retryOption(RetryOption.DEFAULT))
@@ -441,7 +482,7 @@ public class EndToEndTest extends MockCoreConfig {
                         .authenticationKey("global").httpMethod(Method.GET))
                 .responseHandler(responseHandler -> responseHandler
                         .deserializer(response -> CoreHelper.deserialize(response, String.class))
-                        .nullify404(false).globalErrorCase(getGlobalErrorCases()))
+                        .nullify404(false).globalErrorCase(globalErrorCases))
                 .endpointConfiguration(
                         param -> param.arraySerializationFormat(ArraySerializationFormat.INDEXED)
                                 .hasBinaryResponse(false).retryOption(RetryOption.DEFAULT))
@@ -475,49 +516,4 @@ public class EndToEndTest extends MockCoreConfig {
         when(context.getResponse()).thenReturn(response);
         when(response.getStatusCode()).thenReturn(SUCCESS_CODE);
     }
-
-    private Map<String, ErrorCase<CoreApiException>> getGlobalErrorCases() {
-        Map<String, ErrorCase<CoreApiException>> globalErrorCase = new HashMap<>();
-        globalErrorCase.put("400", ErrorCase.setTemplate(
-                "Failed to make the request, {$statusCode} {$response.body#/errors/0/code} - "
-                        + "{$response.body#/errors/0/detail}",
-                (reason, context) -> new GlobalTestException(reason, context)));
-
-        globalErrorCase.put("404", ErrorCase.setReason("Not found",
-                (reason, context) -> new CoreApiException(reason, context)));
-
-        globalErrorCase.put("401",
-                ErrorCase.setTemplate("Failed to make the request, {$response.header.content-type} "
-                        + "{$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
-                        (reason, context) -> new CoreApiException(reason, context)));
-
-        globalErrorCase.put("410",
-                ErrorCase.setTemplate("Failed to make the request, {$response.body}",
-                        (reason, context) -> new CoreApiException(reason, context)));
-
-        globalErrorCase.put("405",
-                ErrorCase.setTemplate("Failed to make the request, {$response.header.accept} "
-                        + "{$response.body#/errors/0/code} - {$response.body#/errors/0/detail}",
-                        (reason, context) -> new CoreApiException(reason, context)));
-
-        globalErrorCase.put("500",
-                ErrorCase.setTemplate("Failed to make the request, http status code: {$statusCode}",
-                        (reason, context) -> new CoreApiException(reason, context)));
-
-        globalErrorCase.put("4XX",
-                ErrorCase.setTemplate(
-                        "Failed to make the request, {$response.body#/errors/0/code} -"
-                                + " {$response.body#/errors/0/detail}",
-                        (reason, context) -> new CoreApiException(reason, context)));
-
-        globalErrorCase.put(ErrorCase.DEFAULT,
-                ErrorCase.setReason(
-                        "Failed to make the request, {$response.body#/errors/0/code} - "
-                                + "{$response.body#/errors/0/detail}",
-                        (reason, context) -> new CoreApiException(reason, context)));
-
-        return globalErrorCase;
-
-    }
-
 }


### PR DESCRIPTION
## What
This PR adds a new method `getReason` in ErrorCase that replace `replacePlaceHolder` method. The `getReason` method returns a new error reason instead of replacing the placeHolders in the original reason. 

## Why
We needed to make sure that the GlobalConfigurations are not updated on performing any API Calls

Closes #89

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [x] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
