### PR TITLE
fix(auth-query-params): include auth query params in request

### DIFF
--- a/src/main/java/io/apimatic/core/HttpRequest.java
+++ b/src/main/java/io/apimatic/core/HttpRequest.java
@@ -122,10 +122,12 @@ public final class HttpRequest {
 
     /**
      * Builds a request with minimal query parameters.
-     * 
+     * @param httpMethod The request HTTP verb.
+     * @param headerParams The request header parameters.
      * @return the {@link Request} instance.
      */
-    private Request buildBasicRequest(Method httpMethod, HttpHeaders headerParams) throws IOException {
+    private Request buildBasicRequest(Method httpMethod, HttpHeaders headerParams)
+            throws IOException {
         return compatibilityFactory.createHttpRequest(httpMethod, null, headerParams,
                 new HashMap<String, Object>(), Collections.emptyList());
     }

--- a/src/main/java/io/apimatic/core/HttpRequest.java
+++ b/src/main/java/io/apimatic/core/HttpRequest.java
@@ -86,10 +86,10 @@ public final class HttpRequest {
 
         applyAuthentication(request, authentication);
         // include auth query parameters in request query params to have them in the query url
-        if(request.getQueryParameters() != null) {
+        if (request.getQueryParameters() != null) {
             queryParams.putAll(request.getQueryParameters());
         }
-        
+
         queryUrlBuilder = getStringBuilder(server, path, queryParams, arraySerializationFormat);
         processTemplateParams(templateParams);
         Object bodyValue = buildBody(body, bodySerializer, bodyParameters);

--- a/src/main/java/io/apimatic/core/HttpRequest.java
+++ b/src/main/java/io/apimatic/core/HttpRequest.java
@@ -81,9 +81,11 @@ public final class HttpRequest {
         this.coreConfig = coreConfig;
         this.compatibilityFactory = coreConfig.getCompatibilityFactory();
         HttpHeaders requestHeaders = addHeaders(headerParams);
+        // Creating a basic request to provide it to auth instances
         Request request = buildBasicRequest(httpMethod, requestHeaders);
 
         applyAuthentication(request, authentication);
+        // include auth query parameters in request query params to have them in the query url
         if(request.getQueryParameters() != null) {
             queryParams.putAll(request.getQueryParameters());
         }
@@ -117,7 +119,12 @@ public final class HttpRequest {
         return compatibilityFactory.createHttpRequest(httpMethod, queryUrlBuilder, headerParams,
                 queryParams, formFields);
     }
-    
+
+    /**
+     * Builds a request with minimal query parameters.
+     * 
+     * @return the {@link Request} instance.
+     */
     private Request buildBasicRequest(Method httpMethod, HttpHeaders headerParams) throws IOException {
         return compatibilityFactory.createHttpRequest(httpMethod, null, headerParams,
                 new HashMap<String, Object>(), Collections.emptyList());

--- a/src/main/java/io/apimatic/core/HttpRequest.java
+++ b/src/main/java/io/apimatic/core/HttpRequest.java
@@ -3,6 +3,7 @@ package io.apimatic.core;
 import java.io.IOException;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -79,16 +80,22 @@ public final class HttpRequest {
             final ArraySerializationFormat arraySerializationFormat) throws IOException {
         this.coreConfig = coreConfig;
         this.compatibilityFactory = coreConfig.getCompatibilityFactory();
-        queryUrlBuilder = getStringBuilder(server, path, queryParams, arraySerializationFormat);
+        HttpHeaders requestHeaders = addHeaders(headerParams);
+        Request request = buildBasicRequest(httpMethod, requestHeaders);
 
+        applyAuthentication(request, authentication);
+        if(request.getQueryParameters() != null) {
+            queryParams.putAll(request.getQueryParameters());
+        }
+        
+        queryUrlBuilder = getStringBuilder(server, path, queryParams, arraySerializationFormat);
         processTemplateParams(templateParams);
         Object bodyValue = buildBody(body, bodySerializer, bodyParameters);
         List<SimpleEntry<String, Object>> formFields =
                 generateFormFields(formParams, formParameters, arraySerializationFormat);
         coreHttpRequest =
-                buildRequest(httpMethod, bodyValue, addHeaders(headerParams), queryParams,
+                buildRequest(httpMethod, bodyValue, requestHeaders, queryParams,
                         formFields, arraySerializationFormat);
-        applyAuthentication(authentication);
     }
 
     /**
@@ -110,15 +117,20 @@ public final class HttpRequest {
         return compatibilityFactory.createHttpRequest(httpMethod, queryUrlBuilder, headerParams,
                 queryParams, formFields);
     }
+    
+    private Request buildBasicRequest(Method httpMethod, HttpHeaders headerParams) throws IOException {
+        return compatibilityFactory.createHttpRequest(httpMethod, null, headerParams,
+                new HashMap<String, Object>(), Collections.emptyList());
+    }
 
-    private void applyAuthentication(Authentication authentication) {
+    private void applyAuthentication(Request request, Authentication authentication) {
         if (authentication != null) {
             authentication.validate();
             if (!authentication.isValid()) {
                 throw new AuthValidationException(authentication.getErrorMessage());
             }
 
-            authentication.apply(coreHttpRequest);
+            authentication.apply(request);
         }
     }
 

--- a/src/test/java/apimatic/core/EndToEndTest.java
+++ b/src/test/java/apimatic/core/EndToEndTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -519,6 +520,9 @@ public class EndToEndTest extends MockCoreConfig {
         when(getCompatibilityFactory().createHttpRequest(any(Method.class),
                 any(StringBuilder.class), any(HttpHeaders.class), anyMap(), anyList()))
                         .thenReturn(coreHttpRequest);
+        when(getCompatibilityFactory().createHttpRequest(any(Method.class),
+                nullable(StringBuilder.class), nullable(HttpHeaders.class), anyMap(), anyList()))
+            .thenReturn(coreHttpRequest);
         when(getCompatibilityFactory().createHttpContext(coreHttpRequest, response))
                 .thenReturn(context);
         when(context.getResponse()).thenReturn(response);

--- a/src/test/java/apimatic/core/RequestBuilderTest.java
+++ b/src/test/java/apimatic/core/RequestBuilderTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.nullable;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.anyList;
@@ -868,6 +869,10 @@ public class RequestBuilderTest extends MockCoreConfig {
         when(getCompatibilityFactory().createHttpRequest(any(Method.class),
                 any(StringBuilder.class), any(HttpHeaders.class), anyMap(), anyList()))
                         .thenReturn(getCoreHttpRequest());
+        
+        when(getCompatibilityFactory().createHttpRequest(any(Method.class),
+                nullable(StringBuilder.class), nullable(HttpHeaders.class), anyMap(), anyList()))
+            .thenReturn(getCoreHttpRequest());
     }
 
     private Employee getEmployeeModel() throws IOException {

--- a/src/test/java/apimatic/core/RequestBuilderTest.java
+++ b/src/test/java/apimatic/core/RequestBuilderTest.java
@@ -869,7 +869,7 @@ public class RequestBuilderTest extends MockCoreConfig {
         when(getCompatibilityFactory().createHttpRequest(any(Method.class),
                 any(StringBuilder.class), any(HttpHeaders.class), anyMap(), anyList()))
                         .thenReturn(getCoreHttpRequest());
-        
+
         when(getCompatibilityFactory().createHttpRequest(any(Method.class),
                 nullable(StringBuilder.class), nullable(HttpHeaders.class), anyMap(), anyList()))
             .thenReturn(getCoreHttpRequest());


### PR DESCRIPTION


## What
This PR fixes the problem of not including auth query parameters in the Api request. Now request builder makes sure to include the query params specific to auth.

## Why
 - To fix a bug that users may encounter with query auth parameters

Closes #95 

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
