### PR TITLE
fix: added null or empty checks for basic auth credentials

### DIFF
--- a/src/main/java/io/apimatic/core/utilities/CoreHelper.java
+++ b/src/main/java/io/apimatic/core/utilities/CoreHelper.java
@@ -1071,10 +1071,10 @@ public class CoreHelper {
      */
     public static String getBase64EncodedCredentials(String basicAuthUserName,
             String basicAuthPassword) {
-        if (basicAuthUserName == null || basicAuthUserName == "") {
+        if (basicAuthUserName == null || basicAuthUserName.equals("")) {
             return null;
         }
-        if (basicAuthPassword == null || basicAuthPassword == "") {
+        if (basicAuthPassword == null || basicAuthPassword.equals("")) {
             return null;
         }
         String authCredentials = basicAuthUserName + ":" + basicAuthPassword;

--- a/src/main/java/io/apimatic/core/utilities/CoreHelper.java
+++ b/src/main/java/io/apimatic/core/utilities/CoreHelper.java
@@ -1071,6 +1071,12 @@ public class CoreHelper {
      */
     public static String getBase64EncodedCredentials(String basicAuthUserName,
             String basicAuthPassword) {
+        if (basicAuthUserName == null || basicAuthUserName == "") {
+            return null;
+        }
+        if (basicAuthPassword == null || basicAuthPassword == "") {
+            return null;
+        }
         String authCredentials = basicAuthUserName + ":" + basicAuthPassword;
         return "Basic " + Base64.getEncoder().encodeToString(authCredentials.getBytes());
     }

--- a/src/test/java/apimatic/core/utilities/CoreHelperTest.java
+++ b/src/test/java/apimatic/core/utilities/CoreHelperTest.java
@@ -138,6 +138,24 @@ public class CoreHelperTest {
     }
 
     @Test
+    public void testBase64EncodingWithNullValue() {
+        String username = null;
+        String password = "password";
+
+        String actualEncodedString = CoreHelper.getBase64EncodedCredentials(username, password);
+        assertEquals(null, actualEncodedString);
+    }
+
+    @Test
+    public void testBase64EncodingWithEmptyValue() {
+        String username = "";
+        String password = "password";
+
+        String actualEncodedString = CoreHelper.getBase64EncodedCredentials(username, password);
+        assertEquals(null, actualEncodedString);
+    }
+
+    @Test
     public void testUrlEncoding() {
         String urlString = "https://localhost:8080%query=0";
         boolean spaceAsPecentage = false;

--- a/src/test/java/apimatic/core/utilities/CoreHelperTest.java
+++ b/src/test/java/apimatic/core/utilities/CoreHelperTest.java
@@ -138,20 +138,22 @@ public class CoreHelperTest {
     }
 
     @Test
-    public void testBase64EncodingWithNullValue() {
-        String username = null;
-        String password = "password";
-
-        String actualEncodedString = CoreHelper.getBase64EncodedCredentials(username, password);
+    public void testBase64EncodingWithNullValues() {
+        String actualEncodedString = CoreHelper.getBase64EncodedCredentials(null, "password");
+        assertEquals(null, actualEncodedString);
+        actualEncodedString = CoreHelper.getBase64EncodedCredentials("username", null);
+        assertEquals(null, actualEncodedString);
+        actualEncodedString = CoreHelper.getBase64EncodedCredentials(null, null);
         assertEquals(null, actualEncodedString);
     }
 
     @Test
-    public void testBase64EncodingWithEmptyValue() {
-        String username = "";
-        String password = "password";
-
-        String actualEncodedString = CoreHelper.getBase64EncodedCredentials(username, password);
+    public void testBase64EncodingWithEmptyValues() {
+        String actualEncodedString = CoreHelper.getBase64EncodedCredentials("", "password");
+        assertEquals(null, actualEncodedString);
+        actualEncodedString = CoreHelper.getBase64EncodedCredentials("username", "");
+        assertEquals(null, actualEncodedString);
+        actualEncodedString = CoreHelper.getBase64EncodedCredentials("", "");
         assertEquals(null, actualEncodedString);
     }
 


### PR DESCRIPTION
## What
This PR fixes a bug when username/password in CoreHelper.getBase64EncodedCredentials is null or empty, and encoded their combination.

## Why
We need to fail the validation if an authentication parameter value is set to an empty string.

Closes #97

## Type of change
Select multiple if applicable.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
N/A

## Testing
Unit tests are added to test the new functionality

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
