### PR TITLE
feat(response): add support for empty payload for nullable types

### DIFF
--- a/src/main/java/io/apimatic/core/utilities/CoreHelper.java
+++ b/src/main/java/io/apimatic/core/utilities/CoreHelper.java
@@ -758,7 +758,7 @@ public class CoreHelper {
             }
             return true;
         }
-        return false;
+        return true;
     }
 
     /**

--- a/src/test/java/apimatic/core/ResponseHandlerTest.java
+++ b/src/test/java/apimatic/core/ResponseHandlerTest.java
@@ -323,6 +323,62 @@ public class ResponseHandlerTest extends MockCoreConfig {
     }
 
     @Test
+    public void testNullableResponseType() throws IOException, CoreApiException {
+        ResponseHandler<String, CoreApiException> coreResponseHandler =
+                new ResponseHandler.Builder<String, CoreApiException>().nullableResponseType(true).build();
+        // stub
+        when(coreHttpResponse.getStatusCode()).thenReturn(SUCCESS_CODE);
+        when(coreHttpResponse.getBody()).thenReturn(null);
+        when(getCompatibilityFactory().createHttpContext(getCoreHttpRequest(), coreHttpResponse))
+                .thenReturn(context);
+
+        // verify
+        assertNull(coreResponseHandler.handle(getCoreHttpRequest(), coreHttpResponse,
+                getMockGlobalConfig(), endpointSetting));
+        
+        when(coreHttpResponse.getBody()).thenReturn("");
+
+        // verify
+        assertNull(coreResponseHandler.handle(getCoreHttpRequest(), coreHttpResponse,
+                getMockGlobalConfig(), endpointSetting));
+
+        when(coreHttpResponse.getBody()).thenReturn("    ");
+
+        // verify
+        assertNull(coreResponseHandler.handle(getCoreHttpRequest(), coreHttpResponse,
+                getMockGlobalConfig(), endpointSetting));
+    }
+
+    @Test
+    public void testNullableResponseTypeFalse() throws IOException, CoreApiException {
+        ResponseHandler<Integer, CoreApiException> coreResponseHandler =
+                new ResponseHandler.Builder<Integer, CoreApiException>().nullableResponseType(false)
+                        .deserializer(response -> Integer.parseInt(response))
+                        .globalErrorCase(getGlobalErrorCases()).build();
+        // stub
+        when(coreHttpResponse.getStatusCode()).thenReturn(SUCCESS_CODE);
+        when(coreHttpResponse.getBody()).thenReturn("50");
+
+        // verify
+        assertEquals(Integer.valueOf(50), coreResponseHandler.handle(getCoreHttpRequest(),
+                coreHttpResponse, getMockGlobalConfig(), endpointSetting));
+        
+        when(coreHttpResponse.getBody()).thenReturn("");
+
+        assertThrows(NumberFormatException.class, () -> {
+            coreResponseHandler.handle(getCoreHttpRequest(), coreHttpResponse,
+                    getMockGlobalConfig(), endpointSetting);
+        });
+
+        when(coreHttpResponse.getBody()).thenReturn("       ");
+
+        assertThrows(NumberFormatException.class, () -> {
+            coreResponseHandler.handle(getCoreHttpRequest(), coreHttpResponse,
+                    getMockGlobalConfig(), endpointSetting);
+        });
+    }
+
+    @Test
     public void testLocalException() throws IOException, CoreApiException {
         ResponseHandler<String, CoreApiException> coreResponseHandler =
                 new ResponseHandler.Builder<String, CoreApiException>()

--- a/src/test/java/apimatic/core/utilities/CoreHelperTest.java
+++ b/src/test/java/apimatic/core/utilities/CoreHelperTest.java
@@ -112,7 +112,7 @@ public class CoreHelperTest {
     @Test
     public void testIsNotWhiteSpace() {
         String whiteSpaceString = "";
-        assertFalse(CoreHelper.isNullOrWhiteSpace(whiteSpaceString));
+        assertTrue(CoreHelper.isNullOrWhiteSpace(whiteSpaceString));
     }
 
     @Test


### PR DESCRIPTION


closes #99

## What
The PR addresses the following changes;
- Added support for handling nullable response types in the ResponseHandler class
- Fixed bug for empty strings in `isNullOrWhitespace` utility in CoreHelper class
- Added unit tests for the changes

## Why
 - To fix the bug for empty string in the `isNullOrWhitespace` utility method
 - To add support for nullable types in response handler to early return when the response is null

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
