### PR TITLE
feat(xml-map): add map of string type serialization/deserialization support

### DIFF
--- a/src/main/java/io/apimatic/core/utilities/MapAdapter.java
+++ b/src/main/java/io/apimatic/core/utilities/MapAdapter.java
@@ -1,0 +1,52 @@
+package io.apimatic.core.utilities;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public class MapAdapter extends XmlAdapter<MapAdapter.EntryList, Map<String, String>> {
+
+    public static class EntryList {
+        @XmlAnyElement
+        public List<Element> entries = new ArrayList<Element>();
+    }
+
+    @Override
+    public EntryList marshal(Map<String, String> map) throws Exception {
+        if (map == null) return null;
+        
+        DocumentBuilder docBuilder;
+        docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        Document document = docBuilder.newDocument();
+        EntryList adaptedMap = new EntryList();
+        for(Entry<String, String> entry : map.entrySet()) {
+            Element element = document.createElement("entry");
+            element.setAttribute("key", entry.getKey());
+            element.setTextContent(entry.getValue());
+            adaptedMap.entries.add(element);
+        }
+        return adaptedMap;
+    }
+
+    @Override
+    public Map<String, String> unmarshal(EntryList adaptedMap) throws Exception {
+        if (adaptedMap == null) return null;
+        
+        HashMap<String, String> map = new HashMap<String, String>();
+        for(Element element : adaptedMap.entries) {
+            map.put(element.getAttribute("key"), element.getTextContent());
+        }
+        return map;
+    }
+
+}

--- a/src/main/java/io/apimatic/core/utilities/MapAdapter.java
+++ b/src/main/java/io/apimatic/core/utilities/MapAdapter.java
@@ -22,7 +22,7 @@ public class MapAdapter extends XmlAdapter<MapAdapter.EntryList, Map<String, Str
     /**
      * Holds the element entries of the map.
      */
-    public static class EntryList {
+    public final static class EntryList {
         @XmlAnyElement
         private List<Element> entries = new ArrayList<Element>();
 

--- a/src/main/java/io/apimatic/core/utilities/MapAdapter.java
+++ b/src/main/java/io/apimatic/core/utilities/MapAdapter.java
@@ -41,8 +41,7 @@ public class MapAdapter extends XmlAdapter<MapAdapter.EntryList, Map<String, Str
             return null;
         }
 
-        DocumentBuilder docBuilder;
-        docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        DocumentBuilder docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
         Document document = docBuilder.newDocument();
         EntryList adaptedMap = new EntryList();
         for (Entry<String, String> entry : map.entrySet()) {

--- a/src/main/java/io/apimatic/core/utilities/MapAdapter.java
+++ b/src/main/java/io/apimatic/core/utilities/MapAdapter.java
@@ -22,10 +22,14 @@ public class MapAdapter extends XmlAdapter<MapAdapter.EntryList, Map<String, Str
     /**
      * Holds the element entries of the map.
      */
-    public final static class EntryList {
+    public static class EntryList {
         @XmlAnyElement
         private List<Element> entries = new ArrayList<Element>();
 
+        /**
+         * Getter for the element entries.
+         * @return entries The list of elements.
+         */
         public List<Element> getEntries() {
             return entries;
         }

--- a/src/main/java/io/apimatic/core/utilities/MapAdapter.java
+++ b/src/main/java/io/apimatic/core/utilities/MapAdapter.java
@@ -14,22 +14,34 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+/**
+ * This is a utility class for XML map marshalling and unmarshalling.
+ */
 public class MapAdapter extends XmlAdapter<MapAdapter.EntryList, Map<String, String>> {
 
+    /**
+     * Holds the element entries of the map.
+     */
     public static class EntryList {
         @XmlAnyElement
-        public List<Element> entries = new ArrayList<Element>();
+        private List<Element> entries = new ArrayList<Element>();
+
+        public List<Element> getEntries() {
+            return entries;
+        }
     }
 
     @Override
     public EntryList marshal(Map<String, String> map) throws Exception {
-        if (map == null) return null;
-        
+        if (map == null) {
+            return null;
+        }
+
         DocumentBuilder docBuilder;
         docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
         Document document = docBuilder.newDocument();
         EntryList adaptedMap = new EntryList();
-        for(Entry<String, String> entry : map.entrySet()) {
+        for (Entry<String, String> entry : map.entrySet()) {
             Element element = document.createElement("entry");
             element.setAttribute("key", entry.getKey());
             element.setTextContent(entry.getValue());
@@ -40,13 +52,14 @@ public class MapAdapter extends XmlAdapter<MapAdapter.EntryList, Map<String, Str
 
     @Override
     public Map<String, String> unmarshal(EntryList adaptedMap) throws Exception {
-        if (adaptedMap == null) return null;
-        
+        if (adaptedMap == null) {
+            return null;
+        }
+
         HashMap<String, String> map = new HashMap<String, String>();
-        for(Element element : adaptedMap.entries) {
+        for (Element element : adaptedMap.entries) {
             map.put(element.getAttribute("key"), element.getTextContent());
         }
         return map;
     }
-
 }

--- a/src/test/java/apimatic/core/utilities/MapAdapterTest.java
+++ b/src/test/java/apimatic/core/utilities/MapAdapterTest.java
@@ -28,10 +28,10 @@ public class MapAdapterTest {
         MapAdapter.EntryList result = mapAdapter.marshal(inputMap);
 
         // Assert
-        assertEquals(2, result.entries.size());
-        assertTrue(result.entries.stream()
+        assertEquals(2, result.getEntries().size());
+        assertTrue(result.getEntries().stream()
                 .anyMatch(e -> e.getAttribute("key").equals("key1") && e.getTextContent().equals("value1")));
-        assertTrue(result.entries.stream()
+        assertTrue(result.getEntries().stream()
                 .anyMatch(e -> e.getAttribute("key").equals("key2") && e.getTextContent().equals("value2")));
     }
 
@@ -45,7 +45,7 @@ public class MapAdapterTest {
 
         // Assert
         assertNotNull(result);
-        assertTrue(result.entries.isEmpty());
+        assertTrue(result.getEntries().isEmpty());
     }
 
     @Test
@@ -62,8 +62,8 @@ public class MapAdapterTest {
         entry2.setTextContent("value2");
 
         MapAdapter.EntryList entryList = new MapAdapter.EntryList();
-        entryList.entries.add(entry1);
-        entryList.entries.add(entry2);
+        entryList.getEntries().add(entry1);
+        entryList.getEntries().add(entry2);
 
         // Act
         Map<String, String> result = mapAdapter.unmarshal(entryList);
@@ -97,8 +97,8 @@ public class MapAdapterTest {
         MapAdapter.EntryList result = mapAdapter.marshal(inputMap);
 
         // Assert
-        assertEquals(1, result.entries.size());
-        assertEquals("", result.entries.get(0).getTextContent());
+        assertEquals(1, result.getEntries().size());
+        assertEquals("", result.getEntries().get(0).getTextContent());
     }
     
     @Test
@@ -135,7 +135,7 @@ public class MapAdapterTest {
         entry1.setTextContent("");
 
         MapAdapter.EntryList entryList = new MapAdapter.EntryList();
-        entryList.entries.add(entry1);
+        entryList.getEntries().add(entry1);
 
         // Act
         Map<String, String> result = mapAdapter.unmarshal(entryList);

--- a/src/test/java/apimatic/core/utilities/MapAdapterTest.java
+++ b/src/test/java/apimatic/core/utilities/MapAdapterTest.java
@@ -1,0 +1,148 @@
+package apimatic.core.utilities;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import io.apimatic.core.utilities.MapAdapter;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MapAdapterTest {
+
+    private final MapAdapter mapAdapter = new MapAdapter();
+
+    @Test
+    public void marshalShouldReturnEntryListWhenGivenNonEmptyMap() throws Exception {
+        // Arrange
+        Map<String, String> inputMap = new HashMap<>();
+        inputMap.put("key1", "value1");
+        inputMap.put("key2", "value2");
+
+        // Act
+        MapAdapter.EntryList result = mapAdapter.marshal(inputMap);
+
+        // Assert
+        assertEquals(2, result.entries.size());
+        assertTrue(result.entries.stream()
+                .anyMatch(e -> e.getAttribute("key").equals("key1") && e.getTextContent().equals("value1")));
+        assertTrue(result.entries.stream()
+                .anyMatch(e -> e.getAttribute("key").equals("key2") && e.getTextContent().equals("value2")));
+    }
+
+    @Test
+    public void marshalShouldReturnEmptyEntryListWhenGivenEmptyMap() throws Exception {
+        // Arrange
+        Map<String, String> inputMap = new HashMap<>();
+
+        // Act
+        MapAdapter.EntryList result = mapAdapter.marshal(inputMap);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.entries.isEmpty());
+    }
+
+    @Test
+    public void unmarshalShouldReturnMapWhenGivenNonEmptyEntryList() throws Exception {
+        // Arrange
+        DocumentBuilder docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        Document document = docBuilder.newDocument();
+        Element entry1 = document.createElement("entry");
+        entry1.setAttribute("key", "key1");
+        entry1.setTextContent("value1");
+
+        Element entry2 = document.createElement("entry");
+        entry2.setAttribute("key", "key2");
+        entry2.setTextContent("value2");
+
+        MapAdapter.EntryList entryList = new MapAdapter.EntryList();
+        entryList.entries.add(entry1);
+        entryList.entries.add(entry2);
+
+        // Act
+        Map<String, String> result = mapAdapter.unmarshal(entryList);
+
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals("value1", result.get("key1"));
+        assertEquals("value2", result.get("key2"));
+    }
+
+    @Test
+    public void unmarshalShouldReturnEmptyMapWhenGivenEmptyEntryList() throws Exception {
+        // Arrange
+        MapAdapter.EntryList entryList = new MapAdapter.EntryList();
+
+        // Act
+        Map<String, String> result = mapAdapter.unmarshal(entryList);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void marshalShouldHandleNullValues() throws Exception {
+        // Arrange
+        Map<String, String> inputMap = new HashMap<>();
+        inputMap.put("key1", null);
+
+        // Act
+        MapAdapter.EntryList result = mapAdapter.marshal(inputMap);
+
+        // Assert
+        assertEquals(1, result.entries.size());
+        assertEquals("", result.entries.get(0).getTextContent());
+    }
+    
+    @Test
+    public void marshalShouldHandleNullMap() throws Exception {
+        // Arrange
+        Map<String, String> inputMap = null;
+
+        // Act
+        MapAdapter.EntryList result = mapAdapter.marshal(inputMap);
+
+        // Assert
+        assertNull(result);
+    }
+
+    @Test
+    public void unmarshalShouldHandleNullEntry() throws Exception {
+        // Arrange
+        MapAdapter.EntryList entryList = null;
+
+        // Act
+        Map<String, String> result = mapAdapter.unmarshal(entryList);
+
+        // Assert
+        assertNull(result);
+    }
+    
+    @Test
+    public void unmarshalShouldHandleEntriesWithEmptyTextContent() throws Exception {
+        // Arrange
+        DocumentBuilder docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        Document document = docBuilder.newDocument();
+        Element entry1 = document.createElement("entry");
+        entry1.setAttribute("key", "key1");
+        entry1.setTextContent("");
+
+        MapAdapter.EntryList entryList = new MapAdapter.EntryList();
+        entryList.entries.add(entry1);
+
+        // Act
+        Map<String, String> result = mapAdapter.unmarshal(entryList);
+
+        // Assert
+        assertEquals(1, result.size());
+        assertEquals("", result.get("key1"));
+    }
+
+}

--- a/src/test/java/apimatic/core/utilities/MapAdapterTest.java
+++ b/src/test/java/apimatic/core/utilities/MapAdapterTest.java
@@ -30,9 +30,11 @@ public class MapAdapterTest {
         // Assert
         assertEquals(2, result.getEntries().size());
         assertTrue(result.getEntries().stream()
-                .anyMatch(e -> e.getAttribute("key").equals("key1") && e.getTextContent().equals("value1")));
+                .anyMatch(e -> e.getAttribute("key").equals("key1")
+                        && e.getTextContent().equals("value1")));
         assertTrue(result.getEntries().stream()
-                .anyMatch(e -> e.getAttribute("key").equals("key2") && e.getTextContent().equals("value2")));
+                .anyMatch(e -> e.getAttribute("key").equals("key2")
+                        && e.getTextContent().equals("value2")));
     }
 
     @Test
@@ -100,7 +102,7 @@ public class MapAdapterTest {
         assertEquals(1, result.getEntries().size());
         assertEquals("", result.getEntries().get(0).getTextContent());
     }
-    
+
     @Test
     public void marshalShouldHandleNullMap() throws Exception {
         // Arrange
@@ -124,7 +126,7 @@ public class MapAdapterTest {
         // Assert
         assertNull(result);
     }
-    
+
     @Test
     public void unmarshalShouldHandleEntriesWithEmptyTextContent() throws Exception {
         // Arrange
@@ -144,5 +146,4 @@ public class MapAdapterTest {
         assertEquals(1, result.size());
         assertEquals("", result.get("key1"));
     }
-
 }


### PR DESCRIPTION
## What
This PR adds support for serialization and deserialization of map of string type properties in the core library. This utility class will be used to annotate and handle map of string type properties in SDK models, ensuring proper serialization and deserialization.


## Why
 - To add support for serialization and deserialization of map using the xml adapter

Closes #101

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
