### PR TITLE
fix(toString): improve output for additional properties using Map.ToString

### DIFF
--- a/src/main/java/io/apimatic/core/types/AdditionalProperties.java
+++ b/src/main/java/io/apimatic/core/types/AdditionalProperties.java
@@ -93,12 +93,7 @@ public class AdditionalProperties<T> {
 
     @Override
     public String toString() {
-        if (properties.isEmpty()) {
-            return "";
-        }
-
-        return properties.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue())
-                .collect(Collectors.joining(", ", ", ", ""));
+        return properties.toString();
     }
 
     /**

--- a/src/main/java/io/apimatic/core/types/AdditionalProperties.java
+++ b/src/main/java/io/apimatic/core/types/AdditionalProperties.java
@@ -5,7 +5,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 

--- a/src/test/java/apimatic/core/type/AdditionalPropertiesTest.java
+++ b/src/test/java/apimatic/core/type/AdditionalPropertiesTest.java
@@ -346,4 +346,29 @@ public class AdditionalPropertiesTest {
             }
         });
     }
+
+    @Test
+    public void testModelWithAdditionalPropertiesToString() throws IOException {
+        ModelWithPrimitiveAdditionalProperties simpleModel =
+                new ModelWithPrimitiveAdditionalProperties.Builder(
+                        "APIMatic").additionalProperty("name", "value").build();
+
+        final String actualSimpleModelToString =
+                "ModelWithPrimitiveAdditionalProperties [company=APIMatic{name=value}]";
+
+        assertEquals(simpleModel.toString(), actualSimpleModelToString);
+
+        ModelWithDateTimeAdditionalProperties dateTimeModel =
+                new ModelWithDateTimeAdditionalProperties.Builder("APIMatic")
+                        .additionalProperty("name",
+                                LocalDateTime.of(DateTimeConstants.YEAR2000, DateTimeConstants.JULY,
+                                        DateTimeConstants.DAY13, DateTimeConstants.HOUR6,
+                                        DateTimeConstants.MINUTES10))
+                        .build();
+
+        final String actualDateTimeModelToString =
+                "ModelWithDateTimeAdditionalProperties [company=APIMatic{name=2000-07-13T06:10}]";
+
+        assertEquals(dateTimeModel.toString(), actualDateTimeModelToString);
+    }
 }


### PR DESCRIPTION
## What
- Refactor the ToString override to utilize Map.ToString

## Why
The current ToString override implementation for additional properties generates an unintuitive output that requires improvement.

Previous toString
```
, additionalProp=string
```

Updated toString
```
additionalProperties={additionalProp=string}
```

Closes #118
