### PR TITLE
ci(snapshot-release): add snapshot package release to the github workflow

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -1,0 +1,36 @@
+name: Snapshot Release To Maven Central
+run-name: Publishing Snapshot Package Version ${{ github.event.inputs.Version }}-SNAPSHOT
+
+on:
+   workflow_dispatch:
+    inputs:
+      Version:
+        description: "This input field requires version in format: x.y.z, where x => major version, y => minor version and z => patch version. Do not include -SNAPSHOT; it will be appended automatically by the workflow for snapshot releases."
+        required: true
+
+jobs:
+  publish:
+    name: Publish the Maven package
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - name: Check out git repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Install Java and Maven setup
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+          
+      - name: Update version in POM
+        run: mvn -B versions:set -DnewVersion=${{ github.event.inputs.Version }}-SNAPSHOT -DgenerateBackupPoms=false
+      - name: Release to Maven Central
+        id: release
+        uses: samuelmeuli/action-maven-publish@v1
+        with:
+          gpg_private_key: ${{ secrets.OSSRH_GPG_SECRET_KEY  }}
+          gpg_passphrase: ${{ secrets.OSSRH_GPG_PASSPHRASE  }}
+          nexus_username: ${{ secrets.OSSRH_USERNAME  }}
+          nexus_password: ${{ secrets.OSSRH_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,7 @@
 			              	<tokenAuth>true</tokenAuth>
 			              	<autoPublish>true</autoPublish>
 			              	<waitUntil>published</waitUntil>
+							<deploymentName>APIMatic Core Library</deploymentName>
 				</configuration>
 		        </plugin>
 			<plugin>


### PR DESCRIPTION

## What
This PR adds a workflow file for the snapshot release to the core library and also overrides the deployment name for the release to maven central.

## Why
To allow testing of the core library in the SDKs before releasing the GA/stable version

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [x] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [ ] My code follows the coding conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
