### PR TITLE
ci: migrate test coverage from CodeClimate to SonarCloud

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,27 +3,31 @@ name: Publish Test Coverage Report
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
   publish-code-coverage-report:
-    name: JAVA 
+    name: JAVA
     runs-on: ubuntu-latest
     if: "! contains(toJSON(github.event.head_commit.message), 'skip ci')"
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 8
-      uses: actions/setup-java@v3
-      with:
-        java-version: '8'
-        distribution: 'temurin'
-        cache: maven
-    - name: Upload coverage report
-      uses: paambaati/codeclimate-action@v3.2.0
-      env:
-        # Set CC_TEST_REPORTER_ID as secret of your repo
-        CC_TEST_REPORTER_ID: ${{secrets.CODE_CLIMATE_TEST_REPORTER_ID}}
-        JACOCO_SOURCE_PATH: "${{github.workspace}}/src/main/java"
-      with:
-        # The report file must be there, otherwise Code Climate won't find it
-        coverageCommand: mvn test
-        coverageLocations: ${{github.workspace}}/target/site/jacoco/jacoco.xml:jacoco
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build and Run Tests with Coverage
+        run: mvn test
+
+      - name: SonarQube Scan
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: SonarSource/sonarqube-scan-action@v5.2.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 [![Maven Central][maven-badge]][maven-url]
 [![Tests][test-badge]][test-url]
 [![Lint Code][lint-badge]][lint-url]
-[![Test Coverage][test-coverage-url]][code-climate-url]
+[![Test Coverage][coverage-badge]][coverage-url]
+[![Maintainability Rating][maintainability-badge]][maintainability-url]
+[![Vulnerabilities][vulnerabilities-badge]][vulnerabilities-url]
 [![Licence][license-badge]][license-url]
 
 ## Introduction
@@ -100,11 +102,17 @@ Core lib's Maven group ID is `io.apimatic`, and its artifact ID is `core`.
 
 [test-url]: https://github.com/apimatic/core-lib-java/actions/workflows/build-and-test.yml
 
-[code-climate-url]: https://codeclimate.com/github/apimatic/core-lib-java
+[coverage-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_core-lib-java&metric=coverage
 
-[maintainability-url]: https://api.codeclimate.com/v1/badges/74e497222508f9e858d6/maintainability
+[coverage-url]: https://sonarcloud.io/summary/new_code?id=apimatic_core-lib-java
 
-[test-coverage-url]: https://api.codeclimate.com/v1/badges/74e497222508f9e858d6/test_coverage
+[maintainability-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_core-lib-java&metric=sqale_rating
+
+[maintainability-url]: https://sonarcloud.io/summary/new_code?id=apimatic_core-lib-java
+
+[vulnerabilities-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_core-lib-java&metric=vulnerabilities
+
+[vulnerabilities-url]: https://sonarcloud.io/summary/new_code?id=apimatic_core-lib-java
 
 [lint-badge]: https://github.com/apimatic/core-lib-java/actions/workflows/linter.yml/badge.svg
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.projectKey=apimatic_core-lib-java
+sonar.projectName=APIMatic Core Library for JAVA
+sonar.organization=apimatic
+sonar.host.url=https://sonarcloud.io
+sonar.sourceEncoding=UTF-8
+
+sonar.sources=src/main/java
+sonar.tests=src/test/java
+
+sonar.java.binaries=target/classes
+
+sonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml


### PR DESCRIPTION
This PR migrates the coverage reporting from Code Climate to SonarCloud. It also adds badges from SonarCloud in Readme.