### PR TITLE
build(deps): remove javax and replacing it by jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,43 +36,15 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>${jackson.databind.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>io.apimatic</groupId>
 			<artifactId>core-interfaces</artifactId>
 			<version>[0.3, 0.4)</version>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-			<version>2.4.0-b180830.0359</version>
-		</dependency>
-		<dependency>
-			<groupId>org.glassfish.jaxb</groupId>
-			<artifactId>jaxb-runtime</artifactId>
-			<version>2.3.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>4.11.0</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-inline</artifactId>
-			<version>4.11.0</version>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.databind.version}</version>
+        </dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
@@ -88,17 +60,30 @@
 			<artifactId>slf4j-api</artifactId>
 			<version>2.0.10</version>
 		</dependency>
-		<dependency>
-			<groupId>org.jacoco</groupId>
-			<artifactId>jacoco-maven-plugin</artifactId>
-			<version>0.8.10</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>javax.json</artifactId>
-			<version>1.1.4</version>
-		</dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/io/apimatic/core/utilities/CoreHelper.java
+++ b/src/main/java/io/apimatic/core/utilities/CoreHelper.java
@@ -31,14 +31,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import javax.json.Json;
-import javax.json.JsonNumber;
-import javax.json.JsonPointer;
-import javax.json.JsonReader;
-import javax.json.JsonString;
-import javax.json.JsonStructure;
-import javax.json.JsonValue;
-import javax.json.JsonWriter;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
@@ -67,6 +59,10 @@ import com.fasterxml.jackson.databind.deser.std.StringDeserializer;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import io.apimatic.core.annotations.TypeCombinator.FormSerialize;
 import io.apimatic.core.annotations.TypeCombinator.TypeCombinatorCase;
 import io.apimatic.core.annotations.TypeCombinator.TypeCombinatorStringCase;
@@ -1607,24 +1603,6 @@ public class CoreHelper {
     }
 
     /**
-     * Converts a JSON string to a {@link JsonStructure}.
-     *
-     * @param json The JSON string.
-     * @return The parsed {@link JsonStructure}, or null if parsing fails.
-     */
-    public static JsonStructure createJsonStructure(String json) {
-        JsonReader jsonReader = Json.createReader(new StringReader(json));
-        JsonStructure jsonStructure = null;
-        try {
-            jsonStructure = jsonReader.read();
-        } catch (Exception e) {
-            // No need to do anything here
-        }
-        jsonReader.close();
-        return jsonStructure;
-    }
-
-    /**
      * Resolves a pointer within a JSON response body or headers.
      *
      * @param pointer     The JSON pointer.
@@ -1658,31 +1636,32 @@ public class CoreHelper {
      * @param json    The JSON string.
      * @return The value as a string, or null if not found or invalid.
      */
-    private static String getValueFromJson(String pointer, String json) {
+    public static String getValueFromJson(String pointer, String json) {
         if (pointer == null || json == null) {
             return null;
         }
 
-        JsonStructure jsonStructure = CoreHelper.createJsonStructure(json);
-        JsonPointer jsonPointer = Json.createPointer(pointer);
-        boolean containsValue = false;
         try {
-            containsValue = jsonPointer.containsValue(jsonStructure);
-        } catch (Exception e) {
-            // Ignore
-        }
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(json);
 
-        if (jsonStructure == null || !containsValue) {
+            // Jackson's .at() supports JSON Pointer syntax
+            JsonNode valueNode = root.at(pointer);
+
+            if (valueNode.isMissingNode() || valueNode.isNull()) {
+                return null;
+            }
+
+            if (valueNode.isTextual()) {
+                return valueNode.asText();
+            }
+
+            // Return JSON representation for non-text values
+            return valueNode.toString();
+        } catch (Exception e) {
+            // Ignore or log as needed
             return null;
         }
-
-        JsonValue value = jsonPointer.getValue(jsonStructure);
-
-        if (value instanceof JsonString) {
-            return ((JsonString) value).getString();
-        }
-
-        return value.toString();
     }
 
     /**
@@ -1694,93 +1673,105 @@ public class CoreHelper {
      * @param updater  The function to apply to the value at the pointer.
      * @return The updated object, or the original if any error occurs.
      */
-    public static <T> T updateValueByPointer(T value, String pointer,
-            UnaryOperator<Object> updater) {
-        if (value == null || "".equals(pointer) || updater == null) {
+    public static <T> T updateValueByPointer(T value, String pointer, UnaryOperator<Object> updater) {
+        if (value == null || pointer == null || pointer.isEmpty() || updater == null) {
             return value;
         }
 
         try {
-            String json = serialize(value);
-            JsonStructure structure = createJsonStructure(json);
-            if (structure == null) {
-                return value;
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.valueToTree(value);
+
+            // Split pointer into parent path and last segment
+            int lastSlash = pointer.lastIndexOf('/');
+            String parentPointer = (lastSlash > 0) ? pointer.substring(0, lastSlash) : "";
+            String fieldName = pointer.substring(lastSlash + 1);
+
+            JsonNode parentNode = parentPointer.isEmpty() ? root : root.at(parentPointer);
+            if (parentNode.isMissingNode() || parentNode.isNull()) {
+                return value; // invalid parent path
             }
 
-            JsonPointer jsonPointer = Json.createPointer(pointer);
-
-            if (!jsonPointer.containsValue(structure)) {
-                structure = jsonPointer.add(structure, JsonValue.NULL);
-            }
-            JsonValue oldJsonValue = jsonPointer.getValue(structure);
-            Object oldValue = toObject(oldJsonValue);
-            Object newValueRaw = updater.apply(oldValue);
-            if (newValueRaw == null) {
-                return value;
+            boolean updated = false;
+            if (parentNode.isObject()) {
+                updated = updateObjectField((ObjectNode) parentNode, fieldName, updater, mapper);
+            } else if (parentNode.isArray()) {
+                updated = updateArrayIndex((ArrayNode) parentNode, fieldName, updater, mapper);
             }
 
-            JsonValue newJsonValue = toJsonValue(newValueRaw);
-            if (newJsonValue == null) {
-                return value;
-            }
-
-            JsonStructure updated = jsonPointer.replace(structure, newJsonValue);
-            StringWriter writer = new StringWriter();
-            try (JsonWriter jsonWriter = Json.createWriter(writer)) {
-                jsonWriter.write(updated);
-            }
-
-            String updatedJson = writer.toString();
-            return deserialize(updatedJson, new TypeReference<T>() {});
-
+            return updated ? mapper.convertValue(root, new TypeReference<T>() {}) : value;
         } catch (Exception e) {
             return value;
         }
     }
+    
+    private static boolean updateObjectField(
+        ObjectNode objectNode,
+        String fieldName,
+        UnaryOperator<Object> updater,
+        ObjectMapper mapper
+    ) {
+        JsonNode oldNode = objectNode.get(fieldName);
+        Object oldValue = toObject(oldNode);
+        Object newValueRaw = updater.apply(oldValue);
 
-    /**
-     * Converts a {@link JsonValue} into a plain Java object.
-     *
-     * @param value The JsonValue.
-     * @return The equivalent Java object.
-     */
-    private static Object toObject(JsonValue value) {
-        switch (value.getValueType()) {
-            case STRING:
-                return ((JsonString) value).getString();
-            case NUMBER:
-                return ((JsonNumber) value).numberValue();
-            case TRUE:
-                return true;
-            case FALSE:
-                return false;
-            default:
-                return null;
+        if (newValueRaw == null) return false;
+        JsonNode newJsonNode = toJsonNode(newValueRaw, mapper);
+        if (newJsonNode == null) return false;
+
+        objectNode.set(fieldName, newJsonNode);
+        return true;
+    }
+
+    private static boolean updateArrayIndex(
+        ArrayNode arrayNode,
+        String indexStr,
+        UnaryOperator<Object> updater,
+        ObjectMapper mapper
+    ) {
+        try {
+            int index = Integer.parseInt(indexStr);
+            if (index < 0 || index >= arrayNode.size()) {
+                return false; // invalid index
+            }
+
+            JsonNode oldNode = arrayNode.get(index);
+            Object oldValue = toObject(oldNode);
+            Object newValueRaw = updater.apply(oldValue);
+
+            if (newValueRaw == null) return false;
+            JsonNode newJsonNode = toJsonNode(newValueRaw, mapper);
+            if (newJsonNode == null) return false;
+
+            arrayNode.set(index, newJsonNode);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
         }
     }
 
-    /**
-     * Converts a plain Java object into a {@link JsonValue}.
-     *
-     * @param obj The object to convert.
-     * @return The corresponding JsonValue or null if unsupported.
-     */
-    private static JsonValue toJsonValue(Object obj) {
-        if (obj instanceof String) {
-            return Json.createValue((String) obj);
+    private static Object toObject(JsonNode node) {
+        if (node == null || node.isNull()) return null;
+        if (node.isTextual()) return node.asText();
+        if (node.isNumber()) return node.numberValue();
+        if (node.isBoolean()) return node.booleanValue();
+
+        return null;
+    }
+
+    private static JsonNode toJsonNode(Object obj, ObjectMapper mapper) {
+        if (obj == null) return NullNode.getInstance();
+
+        if (obj instanceof String ||
+            obj instanceof Integer ||
+            obj instanceof Long ||
+            obj instanceof Double ||
+            obj instanceof Float ||
+            obj instanceof Boolean) {
+            return mapper.valueToTree(obj);
         }
-        if (obj instanceof Integer) {
-            return Json.createValue((Integer) obj);
-        }
-        if (obj instanceof Long) {
-            return Json.createValue((Long) obj);
-        }
-        if (obj instanceof Double) {
-            return Json.createValue((Double) obj);
-        }
-        if (obj instanceof Boolean) {
-            return Boolean.TRUE.equals(obj) ? JsonValue.TRUE : JsonValue.FALSE;
-        }
+
+        // Reject collections, maps, and arbitrary objects
         return null;
     }
 


### PR DESCRIPTION
## What
This commit removes the javax based dependencies and replaces the business logic thats dependent upen javax by jackson based implementation

## Why
This change ensures that `apimatic/core` is neither using `javax.*` nor `jakarta.*` dependencies, to keep it compatible with Java 8.

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [X] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
Yes

## Breaking change
N/A

## Testing
List the steps that were taken to test the changes

## Checklist
- [X] My code follows the coding conventions
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
