### PR TITLE
fix(deps): remove duplicate jacoco-maven-plugin dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,12 +77,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.14</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>4.11.0</version>


### PR DESCRIPTION
## What
Removed a duplicate `jacoco-maven-plugin` dependency entry from `pom.xml`. The dependency with `groupId` `org.jacoco` and version `0.8.14` (test scope) was declared twice, and this PR removes the redundant declaration.

## Why
Having duplicate dependency declarations in `pom.xml` can cause confusion and potential version conflicts during builds. Removing the duplicate keeps the dependency management clean and unambiguous.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [x] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
No new dependencies added. A duplicate `jacoco-maven-plugin` entry has been removed.

## Breaking change
No breaking changes introduced.